### PR TITLE
Fix readme file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ A Model Context Protocol (MCP) plugin that allows Claude Desktop to interact dir
    > **Note**: This project uses a custom Figma plugin located in the `src/claude_mcp_plugin` folder.
 
    - Open Figma
-   - Go to **Menu > Plugins > Development > New Plugin**
+   - Go to **Menu > Plugins > Development**
    - Select "Import plugin from manifest"
    - Navigate and select the `src/claude_mcp_plugin/src/claude_mcp_plugin/manifest.json` file from this repository
 


### PR DESCRIPTION

In Figma, when navigating to Menu > Plugins > Development > New Plugin, the interface now shows the following screens

![image](https://github.com/user-attachments/assets/22b39ceb-2cc1-4577-8569-10bd087f0ff4)

![image](https://github.com/user-attachments/assets/780e5b5d-e257-4085-bc15-a79d0db843a0)

Based on the current UI, I updated the instructions in the README to more accurately reflect the actual steps

![image](https://github.com/user-attachments/assets/b6838922-9159-4bba-b669-d831b7694e3e)

```md
 - Go to **Menu > Plugins > Development**
 - Select "Import plugin from manifest"
```

