### PR TITLE
replace || operator with safe defaults in set_stroke_color

### DIFF
--- a/src/claude_mcp_plugin/code.js
+++ b/src/claude_mcp_plugin/code.js
@@ -560,7 +560,7 @@ async function setStrokeColor(params) {
   const {
     nodeId,
     color: { r, g, b, a },
-    weight = 1,
+    strokeWeight,
   } = params || {};
 
   if (!nodeId) {
@@ -576,15 +576,30 @@ async function setStrokeColor(params) {
     throw new Error(`Node does not support strokes: ${nodeId}`);
   }
 
-  // Create RGBA color
-  const rgbColor = {
-    r: r !== undefined ? r : 0,
-    g: g !== undefined ? g : 0,
-    b: b !== undefined ? b : 0,
-    a: a !== undefined ? a : 1,
-  };
+  if (r === undefined || g === undefined || b === undefined || a === undefined) {
+    throw new Error("Incomplete color data received from MCP layer. All RGBA components must be provided.");
+  }
+  
+  if (strokeWeight === undefined) {
+    throw new Error("Stroke weight must be provided by MCP layer.");
+  }
 
-  // Set stroke
+  const rgbColor = {
+    r: parseFloat(r),
+    g: parseFloat(g),
+    b: parseFloat(b),
+    a: parseFloat(a)
+  };
+  const strokeWeightParsed = parseFloat(strokeWeight);
+
+  if (isNaN(rgbColor.r) || isNaN(rgbColor.g) || isNaN(rgbColor.b) || isNaN(rgbColor.a)) {
+    throw new Error("Invalid color values received - all components must be valid numbers");
+  }
+  
+  if (isNaN(strokeWeightParsed)) {
+    throw new Error("Invalid stroke weight - must be a valid number");
+  }
+
   const paintStyle = {
     type: "SOLID",
     color: {
@@ -599,7 +614,7 @@ async function setStrokeColor(params) {
 
   // Set stroke weight if available
   if ("strokeWeight" in node) {
-    node.strokeWeight = weight;
+    node.strokeWeight = strokeWeightParsed;
   }
 
   return {

--- a/src/talk_to_figma_mcp/tools/modification-tools.ts
+++ b/src/talk_to_figma_mcp/tools/modification-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { sendCommandToFigma } from "../utils/websocket";
-import { applyColorDefaults } from "../utils/defaults";
+import { applyColorDefaults, applyDefault, FIGMA_DEFAULTS } from "../utils/defaults";
 import { Color } from "../types/color";
 
 /**
@@ -61,7 +61,7 @@ export function registerModificationTools(server: McpServer): void {
   // Set Stroke Color Tool
   server.tool(
     "set_stroke_color",
-    "Set the stroke color of a node in Figma",
+    "Set the stroke color of a node in Figma (defaults: opacity 1, weight 1)",
     {
       nodeId: z.string().describe("The ID of the node to modify"),
       r: z.number().min(0).max(1).describe("Red component (0-1)"),
@@ -72,17 +72,27 @@ export function registerModificationTools(server: McpServer): void {
     },
     async ({ nodeId, r, g, b, a, weight }) => {
       try {
+
+        if (r === undefined || g === undefined || b === undefined) {
+          throw new Error("RGB components (r, g, b) are required and cannot be undefined");
+        }
+        
+        const colorInput: Color = { r, g, b, a };
+        const colorWithDefaults = applyColorDefaults(colorInput);
+        
+        const strokeWeight = applyDefault(weight, FIGMA_DEFAULTS.stroke.weight);
+        
         const result = await sendCommandToFigma("set_stroke_color", {
           nodeId,
-          color: { r, g, b, a: a || 1 },
-          weight: weight || 1,
+          color: colorWithDefaults,
+          weight: strokeWeight,
         });
         const typedResult = result as { name: string };
         return {
           content: [
             {
               type: "text",
-              text: `Set stroke color of node "${typedResult.name}" to RGBA(${r}, ${g}, ${b}, ${a || 1}) with weight ${weight || 1}`,
+              text: `Set stroke color of node "${typedResult.name}" to RGBA(${r}, ${g}, ${b}, ${colorWithDefaults.a}) with weight ${strokeWeight}`,
             },
           ],
         };

--- a/src/talk_to_figma_mcp/tools/modification-tools.ts
+++ b/src/talk_to_figma_mcp/tools/modification-tools.ts
@@ -68,9 +68,9 @@ export function registerModificationTools(server: McpServer): void {
       g: z.number().min(0).max(1).describe("Green component (0-1)"),
       b: z.number().min(0).max(1).describe("Blue component (0-1)"),
       a: z.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
-      weight: z.number().positive().optional().describe("Stroke weight"),
+      strokeWeight: z.number().positive().optional().describe("Stroke weight"),
     },
-    async ({ nodeId, r, g, b, a, weight }) => {
+    async ({ nodeId, r, g, b, a, strokeWeight }) => {
       try {
 
         if (r === undefined || g === undefined || b === undefined) {
@@ -80,19 +80,19 @@ export function registerModificationTools(server: McpServer): void {
         const colorInput: Color = { r, g, b, a };
         const colorWithDefaults = applyColorDefaults(colorInput);
         
-        const strokeWeight = applyDefault(weight, FIGMA_DEFAULTS.stroke.weight);
+        const strokeWeightWithDefault = applyDefault(strokeWeight, FIGMA_DEFAULTS.stroke.weight);
         
         const result = await sendCommandToFigma("set_stroke_color", {
           nodeId,
           color: colorWithDefaults,
-          weight: strokeWeight,
+          strokeWeight: strokeWeightWithDefault,
         });
         const typedResult = result as { name: string };
         return {
           content: [
             {
               type: "text",
-              text: `Set stroke color of node "${typedResult.name}" to RGBA(${r}, ${g}, ${b}, ${colorWithDefaults.a}) with weight ${strokeWeight}`,
+              text: `Set stroke color of node "${typedResult.name}" to RGBA(${r}, ${g}, ${b}, ${colorWithDefaults.a}) with weight ${strokeWeightWithDefault}`,
             },
           ],
         };

--- a/src/talk_to_figma_mcp/utils/defaults.ts
+++ b/src/talk_to_figma_mcp/utils/defaults.ts
@@ -3,21 +3,16 @@ import { Color, ColorWithDefaults } from '../types/color';
 export const FIGMA_DEFAULTS = {
   color: {
     opacity: 1,
+  },
+  stroke: {
+    weight: 1,
   }
 } as const;
 
-/**
- * Safely applies a default value only when the input is undefined.
- * Unlike || operator, this preserves falsy values like 0.
- */
 export function applyDefault<T>(value: T | undefined, defaultValue: T): T {
   return value !== undefined ? value : defaultValue;
 }
 
-/**
- * Applies default values to a color object.
- * Alpha defaults to 1 if not specified, but preserves 0 (transparency).
- */
 export function applyColorDefaults(color: Color): ColorWithDefaults {
   return {
     r: color.r,

--- a/tests/integration/set-fill-color.test.ts
+++ b/tests/integration/set-fill-color.test.ts
@@ -52,7 +52,6 @@ describe("set_fill_color tool integration", () => {
         // a is undefined
       });
 
-      // Verify WebSocket was called with correct payload
       expect(mockSendCommand).toHaveBeenCalledTimes(1);
       const [command, payload] = mockSendCommand.mock.calls[0];
       expect(command).toBe("set_fill_color");
@@ -61,7 +60,6 @@ describe("set_fill_color tool integration", () => {
         color: { r: 0.2, g: 0.4, b: 0.6, a: 1 },
       });
 
-      // Verify response message
       expect(response.content[0].text).toContain("RGBA(0.2, 0.4, 0.6, 1)");
     });
 
@@ -74,12 +72,10 @@ describe("set_fill_color tool integration", () => {
         a: 0, // This should be preserved as 0, not converted to 1
       });
 
-      // Verify WebSocket payload preserves opacity 0
       expect(mockSendCommand).toHaveBeenCalledTimes(1);
       const [command, payload] = mockSendCommand.mock.calls[0];
       expect(payload.color.a).toBe(0); // Critical: should be 0, not 1
 
-      // Verify response message shows 0
       expect(response.content[0].text).toContain("RGBA(0.1, 0.3, 0.5, 0)");
     });
 

--- a/tests/integration/set-stroke-color.test.ts
+++ b/tests/integration/set-stroke-color.test.ts
@@ -1,0 +1,392 @@
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerModificationTools } from '../../src/talk_to_figma_mcp/tools/modification-tools';
+
+jest.mock('../../src/talk_to_figma_mcp/utils/websocket', () => ({
+  sendCommandToFigma: jest.fn().mockResolvedValue({ name: "MockNode" })
+}));
+
+describe("set_stroke_color tool integration", () => {
+  let server: McpServer;
+  let mockSendCommand: jest.Mock;
+  let toolHandler: Function;
+  let toolSchema: z.ZodObject<any>;
+
+  beforeEach(() => {
+    server = new McpServer(
+      { name: 'test-server', version: '1.0.0' },
+      { capabilities: { tools: {} } }
+    );
+    
+    mockSendCommand = require('../../src/talk_to_figma_mcp/utils/websocket').sendCommandToFigma;
+    mockSendCommand.mockClear();
+    
+    const originalTool = server.tool.bind(server);
+    jest.spyOn(server, 'tool').mockImplementation((...args: any[]) => {
+      if (args.length === 4) {
+        const [name, description, schema, handler] = args;
+        if (name === 'set_stroke_color') {
+          toolHandler = handler;
+          toolSchema = z.object(schema);
+        }
+      }
+      return (originalTool as any)(...args);
+    });
+    
+    registerModificationTools(server);
+  });
+
+  async function callToolWithValidation(args: any) {
+    const validatedArgs = toolSchema.parse(args);
+    const result = await toolHandler(validatedArgs, { meta: {} });
+    return result;
+  }
+
+  describe("opacity handling (the critical fix)", () => {
+    it("defaults `a` to 1 when `a` is undefined", async () => {
+      const response = await callToolWithValidation({
+        nodeId: "nodeA",
+        r: 0.2,
+        g: 0.4,
+        b: 0.6,
+        // a is undefined
+        strokeWeight: 2,
+      });
+
+      // Verify WebSocket was called with correct payload
+      expect(mockSendCommand).toHaveBeenCalledTimes(1);
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(command).toBe("set_stroke_color");
+      expect(payload).toEqual({
+        nodeId: "nodeA",
+        color: { r: 0.2, g: 0.4, b: 0.6, a: 1 },
+        strokeWeight: 2,
+      });
+
+      // Verify response message
+      expect(response.content[0].text).toContain("RGBA(0.2, 0.4, 0.6, 1)");
+      expect(response.content[0].text).toContain("weight 2");
+    });
+
+    it("preserves `a = 0` when explicitly provided (the main bug fix)", async () => {
+      const response = await callToolWithValidation({
+        nodeId: "nodeB",
+        r: 0.1,
+        g: 0.3,
+        b: 0.5,
+        a: 0, // This should be preserved as 0, not converted to 1
+        strokeWeight: 1.5,
+      });
+
+      // Verify WebSocket payload preserves opacity 0
+      expect(mockSendCommand).toHaveBeenCalledTimes(1);
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color.a).toBe(0); // Critical: should be 0, not 1
+      expect(payload.strokeWeight).toBe(1.5);
+
+      // Verify response message shows 0
+      expect(response.content[0].text).toContain("RGBA(0.1, 0.3, 0.5, 0)");
+      expect(response.content[0].text).toContain("weight 1.5");
+    });
+
+    it("preserves semi-transparent values", async () => {
+      const response = await callToolWithValidation({
+        nodeId: "nodeC",
+        r: 1,
+        g: 0,
+        b: 0,
+        a: 0.5,
+        strokeWeight: 3,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color.a).toBe(0.5);
+      expect(payload.strokeWeight).toBe(3);
+      expect(response.content[0].text).toContain("RGBA(1, 0, 0, 0.5)");
+      expect(response.content[0].text).toContain("weight 3");
+    });
+  });
+
+  describe("stroke weight handling (the other critical fix)", () => {
+    it("defaults strokeWeight to 1 when undefined", async () => {
+      const response = await callToolWithValidation({
+        nodeId: "nodeD",
+        r: 0.5,
+        g: 0.5,
+        b: 0.5,
+        a: 1,
+        // strokeWeight is undefined
+      });
+
+      expect(mockSendCommand).toHaveBeenCalledTimes(1);
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.strokeWeight).toBe(1); // Should default to 1
+      expect(response.content[0].text).toContain("weight 1");
+    });
+
+    it("preserves provided strokeWeight values", async () => {
+      const response = await callToolWithValidation({
+        nodeId: "nodeE",
+        r: 0.5,
+        g: 0.5,
+        b: 0.5,
+        a: 1,
+        strokeWeight: 5.5,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.strokeWeight).toBe(5.5);
+      expect(response.content[0].text).toContain("weight 5.5");
+    });
+
+    it("handles decimal strokeWeight values", async () => {
+      await callToolWithValidation({
+        nodeId: "nodeF",
+        r: 0.2,
+        g: 0.3,
+        b: 0.4,
+        a: 0.8,
+        strokeWeight: 0.5,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.strokeWeight).toBe(0.5);
+    });
+  });
+
+  describe("RGB component handling", () => {
+    it("preserves pure black (0,0,0)", async () => {
+      await callToolWithValidation({
+        nodeId: "nodeG",
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 1,
+        strokeWeight: 1,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color.r).toBe(0);
+      expect(payload.color.g).toBe(0);
+      expect(payload.color.b).toBe(0);
+    });
+
+    it("preserves zero red component", async () => {
+      await callToolWithValidation({
+        nodeId: "nodeH1",
+        r: 0,
+        g: 0.5,
+        b: 0.8,
+        a: 1,
+        strokeWeight: 2,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color.r).toBe(0);
+      expect(payload.color.g).toBe(0.5);
+    });
+
+    it("preserves zero green component", async () => {
+      await callToolWithValidation({
+        nodeId: "nodeH2",
+        r: 0.5,
+        g: 0,
+        b: 0.8,
+        a: 1,
+        strokeWeight: 2,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color.g).toBe(0);
+    });
+
+    it("preserves zero blue component", async () => {
+      await callToolWithValidation({
+        nodeId: "nodeH3",
+        r: 0.5,
+        g: 0.8,
+        b: 0,
+        a: 1,
+        strokeWeight: 2,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color.b).toBe(0);
+    });
+  });
+
+  describe("Zod validation (real validation layer)", () => {
+    it("rejects undefined r component", async () => {
+      await expect(callToolWithValidation({
+        nodeId: "nodeI1",
+        // r is missing
+        g: 0.5,
+        b: 0.8,
+        a: 1,
+        strokeWeight: 1,
+      })).rejects.toThrow();
+      
+      // WebSocket should not be called if validation fails
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("rejects undefined g component", async () => {
+      await expect(callToolWithValidation({
+        nodeId: "nodeI2",
+        r: 0.5,
+        // g is missing
+        b: 0.8,
+        a: 1,
+        strokeWeight: 1,
+      })).rejects.toThrow();
+      
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("rejects undefined b component", async () => {
+      await expect(callToolWithValidation({
+        nodeId: "nodeI3",
+        r: 0.5,
+        g: 0.8,
+        // b is missing
+        a: 1,
+        strokeWeight: 1,
+      })).rejects.toThrow();
+      
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("rejects zero strokeWeight (should be positive)", async () => {
+      await expect(callToolWithValidation({
+        nodeId: "nodeI4",
+        r: 0.5,
+        g: 0.5,
+        b: 0.5,
+        a: 1,
+        strokeWeight: 0, // Should be positive
+      })).rejects.toThrow();
+      
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("rejects negative strokeWeight", async () => {
+      await expect(callToolWithValidation({
+        nodeId: "nodeI5",
+        r: 0.5,
+        g: 0.5,
+        b: 0.5,
+        a: 1,
+        strokeWeight: -1, // Should be positive
+      })).rejects.toThrow();
+      
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("rejects string strokeWeight", async () => {
+      await expect(callToolWithValidation({
+        nodeId: "nodeI6",
+        r: 0.5,
+        g: 0.5,
+        b: 0.5,
+        a: 1,
+        strokeWeight: "thick", // Invalid type
+      })).rejects.toThrow();
+      
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("rejects out-of-range color values", async () => {
+      await expect(callToolWithValidation({
+        nodeId: "nodeI7",
+        r: 1.5, // Out of 0-1 range
+        g: 0.5,
+        b: 0.8,
+        a: 1,
+        strokeWeight: 1,
+      })).rejects.toThrow();
+      
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("rejects negative color values", async () => {
+      await expect(callToolWithValidation({
+        nodeId: "nodeI8",
+        r: -0.1, // Negative value
+        g: 0.5,
+        b: 0.8,
+        a: 1,
+        strokeWeight: 1,
+      })).rejects.toThrow();
+      
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles transparent stroke correctly", async () => {
+      const response = await callToolWithValidation({
+        nodeId: "nodeJ",
+        r: 1,
+        g: 0,
+        b: 0,
+        a: 0, // Transparent red stroke
+        strokeWeight: 5,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color).toEqual({ r: 1, g: 0, b: 0, a: 0 });
+      expect(payload.strokeWeight).toBe(5);
+      expect(response.content[0].text).toContain("RGBA(1, 0, 0, 0)");
+      expect(response.content[0].text).toContain("weight 5");
+    });
+
+    it("handles boundary values", async () => {
+      const response = await callToolWithValidation({
+        nodeId: "nodeK",
+        r: 1,
+        g: 1,
+        b: 1,
+        a: 1,
+        strokeWeight: 10,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color).toEqual({ r: 1, g: 1, b: 1, a: 1 });
+      expect(payload.strokeWeight).toBe(10);
+    });
+
+    it("accepts valid decimal values", async () => {
+      await callToolWithValidation({
+        nodeId: "nodeL",
+        r: 0.123,
+        g: 0.456,
+        b: 0.789,
+        a: 0.5,
+        strokeWeight: 2.75,
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color.r).toBeCloseTo(0.123);
+      expect(payload.color.g).toBeCloseTo(0.456);
+      expect(payload.color.b).toBeCloseTo(0.789);
+      expect(payload.color.a).toBeCloseTo(0.5);
+      expect(payload.strokeWeight).toBeCloseTo(2.75);
+    });
+
+    it("handles both defaults simultaneously", async () => {
+      const response = await callToolWithValidation({
+        nodeId: "nodeM",
+        r: 0.8,
+        g: 0.2,
+        b: 0.4,
+        // Both a and strokeWeight are undefined, should get defaults
+      });
+
+      const [command, payload] = mockSendCommand.mock.calls[0];
+      expect(payload.color.a).toBe(1); // Default opacity
+      expect(payload.strokeWeight).toBe(1); // Default weight
+      expect(response.content[0].text).toContain("RGBA(0.8, 0.2, 0.4, 1)");
+      expect(response.content[0].text).toContain("weight 1");
+    });
+  });
+});

--- a/tests/integration/set-stroke-color.test.ts
+++ b/tests/integration/set-stroke-color.test.ts
@@ -53,7 +53,6 @@ describe("set_stroke_color tool integration", () => {
         strokeWeight: 2,
       });
 
-      // Verify WebSocket was called with correct payload
       expect(mockSendCommand).toHaveBeenCalledTimes(1);
       const [command, payload] = mockSendCommand.mock.calls[0];
       expect(command).toBe("set_stroke_color");
@@ -63,7 +62,6 @@ describe("set_stroke_color tool integration", () => {
         strokeWeight: 2,
       });
 
-      // Verify response message
       expect(response.content[0].text).toContain("RGBA(0.2, 0.4, 0.6, 1)");
       expect(response.content[0].text).toContain("weight 2");
     });
@@ -78,13 +76,11 @@ describe("set_stroke_color tool integration", () => {
         strokeWeight: 1.5,
       });
 
-      // Verify WebSocket payload preserves opacity 0
       expect(mockSendCommand).toHaveBeenCalledTimes(1);
       const [command, payload] = mockSendCommand.mock.calls[0];
-      expect(payload.color.a).toBe(0); // Critical: should be 0, not 1
+      expect(payload.color.a).toBe(0);
       expect(payload.strokeWeight).toBe(1.5);
 
-      // Verify response message shows 0
       expect(response.content[0].text).toContain("RGBA(0.1, 0.3, 0.5, 0)");
       expect(response.content[0].text).toContain("weight 1.5");
     });
@@ -226,7 +222,6 @@ describe("set_stroke_color tool integration", () => {
         strokeWeight: 1,
       })).rejects.toThrow();
       
-      // WebSocket should not be called if validation fails
       expect(mockSendCommand).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/utils/defaults.test.ts
+++ b/tests/unit/utils/defaults.test.ts
@@ -97,14 +97,36 @@ describe('defaults utilities', () => {
   });
 
   describe('FIGMA_DEFAULTS', () => {
-    it('should have correct default opacity', () => {
-      expect(FIGMA_DEFAULTS.color.opacity).toBe(1);
-    });
-
     it('should be a const object with expected structure', () => {
       expect(FIGMA_DEFAULTS).toHaveProperty('color');
       expect(FIGMA_DEFAULTS.color).toHaveProperty('opacity');
       expect(typeof FIGMA_DEFAULTS.color.opacity).toBe('number');
+      
+      expect(FIGMA_DEFAULTS).toHaveProperty('stroke');
+      expect(FIGMA_DEFAULTS.stroke).toHaveProperty('weight');
+      expect(typeof FIGMA_DEFAULTS.stroke.weight).toBe('number');
+    });
+  });
+
+  describe('applyDefault with stroke weight scenarios', () => {
+    it('should preserve strokeWeight 0.5 (thin stroke)', () => {
+      const result = applyDefault(0.5, FIGMA_DEFAULTS.stroke.weight);
+      expect(result).toBe(0.5);
+    });
+
+    it('should preserve strokeWeight 10 (thick stroke)', () => {
+      const result = applyDefault(10, FIGMA_DEFAULTS.stroke.weight);
+      expect(result).toBe(10);
+    });
+
+    it('should default undefined strokeWeight to 1', () => {
+      const result = applyDefault(undefined, FIGMA_DEFAULTS.stroke.weight);
+      expect(result).toBe(1);
+    });
+
+    it('should preserve strokeWeight with decimal precision', () => {
+      const result = applyDefault(2.75, FIGMA_DEFAULTS.stroke.weight);
+      expect(result).toBe(2.75);
     });
   });
 });

--- a/tests/unit/utils/defaults.test.ts
+++ b/tests/unit/utils/defaults.test.ts
@@ -69,7 +69,6 @@ describe('defaults utilities', () => {
         
         expect(result).toEqual(expected);
         
-        // Ensure RGB values are preserved exactly
         expect(result.r).toBe(input.r);
         expect(result.g).toBe(input.g);
         expect(result.b).toBe(input.b);


### PR DESCRIPTION
## Summary
Replace problematic `||` operator with safe default utilities, following the established pattern from `set_fill_color`.

<img width="450" alt="image" src="https://github.com/user-attachments/assets/afa51dce-11e4-4a1f-9b7c-a09b671eb020" />


## Solution
  **Design Pattern**: MCP layer validates and applies defaults, Figma plugin acts as pure pass-through

### MCP Layer
  - Uses `applyColorDefaults()` and `applyDefault()` utilities that preserve values
  - Added `FIGMA_DEFAULTS.stroke.weight: 1` for centralized configuration
  - Validates RGB components are provided
  - Renamed `weight` to `strokeWeight` for clarity

### Figma Plugin
  - Removed all default logic - expects complete data from MCP
  - Added validation to ensure MCP provided all required values
  - Pure translator between MCP and Figma API

## Testing
  - Added tests for `set_stroke_color`