### PR TITLE
fix: remove default empty string from join_channel parameter

### DIFF
--- a/src/talk_to_figma_mcp/tools/document-tools.ts
+++ b/src/talk_to_figma_mcp/tools/document-tools.ts
@@ -301,7 +301,7 @@ export function registerDocumentTools(server: McpServer): void {
     "join_channel",
     "Join a specific channel to communicate with Figma",
     {
-      channel: z.string().describe("The name of the channel to join").default(""),
+      channel: z.string().describe("The name of the channel to join"),
     },
     async ({ channel }) => {
       try {
@@ -323,7 +323,7 @@ export function registerDocumentTools(server: McpServer): void {
 
         // Use joinChannel instead of sendCommandToFigma to ensure currentChannel is updated
         await joinChannel(channel);
-        
+
         return {
           content: [
             {


### PR DESCRIPTION
The default empty string on the channel parameter was causing keyValidator._parse errors. Channel should be a required parameter.

Fixes #28