### PR TITLE
feat: Add rename_node tool for renaming any node in Figma

### DIFF
--- a/src/claude_mcp_plugin/code.js
+++ b/src/claude_mcp_plugin/code.js
@@ -189,6 +189,8 @@ async function handleCommand(command, params) {
       return await createVector(params);
     case "create_line":
       return await createLine(params);
+    case "rename_node":
+      return await renameNode(params);
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -3291,5 +3293,37 @@ async function createLine(params) {
     strokes: line.strokes,
     vectorPaths: line.vectorPaths,
     parentId: line.parent ? line.parent.id : undefined
+  };
+}
+
+// Rename a node (frame, component, group, etc.)
+async function renameNode(params) {
+  const { nodeId, name } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  if (!name) {
+    throw new Error("Missing name parameter");
+  }
+
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node) {
+    throw new Error(`Node not found with ID: ${nodeId}`);
+  }
+
+  if (node.type === "DOCUMENT") {
+    throw new Error("Cannot rename the document node");
+  }
+
+  const oldName = node.name;
+  node.name = name;
+
+  return {
+    id: node.id,
+    name: node.name,
+    oldName: oldName,
+    type: node.type
   };
 }

--- a/src/talk_to_figma_mcp/tools/modification-tools.ts
+++ b/src/talk_to_figma_mcp/tools/modification-tools.ts
@@ -405,4 +405,40 @@ export function registerModificationTools(server: McpServer): void {
       }
     }
   );
+
+  // Rename Node Tool
+  server.tool(
+    "rename_node",
+    "Rename a node (frame, component, group, etc.) in Figma",
+    {
+      nodeId: z.string().describe("The ID of the node to rename"),
+      name: z.string().describe("The new name for the node"),
+    },
+    async ({ nodeId, name }) => {
+      try {
+        const result = await sendCommandToFigma("rename_node", {
+          nodeId,
+          name,
+        });
+        const typedResult = result as { id: string; name: string; oldName: string; type: string };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Renamed ${typedResult.type} from "${typedResult.oldName}" to "${typedResult.name}"`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error renaming node: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
 }


### PR DESCRIPTION
## Summary
- Add `rename_node` MCP tool to rename any node (frames, components, groups, text, etc.)
- Useful for organizing designs and maintaining clean layer names

## Changes
- `src/claude_mcp_plugin/code.js`: Add `renameNode` function handler
- `src/talk_to_figma_mcp/tools/modification-tools.ts`: Register `rename_node` MCP tool

## Usage
```javascript
rename_node({ nodeId: "123:456", name: "New Frame Name" })
```

## Response
```json
{
  "id": "123:456",
  "name": "New Frame Name",
  "oldName": "Old Frame Name",
  "type": "FRAME"
}
```

## Test plan
- [ ] Rename a frame node
- [ ] Rename a component node
- [ ] Rename a text node
- [ ] Verify error handling for invalid nodeId
- [ ] Verify error handling for missing name parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)