### PR TITLE
feat: add set_text_style_id tool

### DIFF
--- a/src/talk_to_figma_mcp/tools/text-tools.ts
+++ b/src/talk_to_figma_mcp/tools/text-tools.ts
@@ -493,6 +493,42 @@ export function registerTextTools(server: McpServer): void {
     }
   );
 
+  // Set Text Style ID Tool
+  server.tool(
+    "set_text_style_id",
+    "Apply a text style to a text node in Figma",
+    {
+      nodeId: z.string().describe("The ID of the text node to modify"),
+      textStyleId: z.string().describe("The ID of the text style to apply"),
+    },
+    async ({ nodeId, textStyleId }) => {
+      try {
+        const result = await sendCommandToFigma("set_text_style_id", {
+          nodeId,
+          textStyleId
+        });
+        const typedResult = result as { name: string, textStyleId: string, styleName: string };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Applied text style "${typedResult.styleName}" to node "${typedResult.name}"`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error setting text style: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ]
+        };
+      }
+    }
+  );
+
   // Load Font Async Tool
   server.tool(
     "load_font_async",

--- a/src/talk_to_figma_mcp/types/index.ts
+++ b/src/talk_to_figma_mcp/types/index.ts
@@ -81,6 +81,7 @@ export type FigmaCommand =
   | "get_remote_components"
   | "set_effects"
   | "set_effect_style_id"
+  | "set_text_style_id"
   | "group_nodes"
   | "ungroup_nodes"
   | "flatten_node"


### PR DESCRIPTION
## Summary
- Add new MCP tool `set_text_style_id` to apply text styles to text nodes
- Uses `setTextStyleIdAsync` for compatibility with dynamic-page document access mode
- Includes validation for node type and style existence before applying

## Test plan
- [x] Tested applying local text styles to text nodes in Figma
- [x] Verified error handling for non-text nodes and invalid style IDs

🤖 Generated with [Claude Code](https://claude.ai/code)