### PR TITLE
feat: add text alignment support for RTL/Arabic text

### DIFF
--- a/src/talk_to_figma_mcp/tools/creation-tools.ts
+++ b/src/talk_to_figma_mcp/tools/creation-tools.ts
@@ -178,8 +178,16 @@ export function registerCreationTools(server: McpServer): void {
         .string()
         .optional()
         .describe("Optional parent node ID to append the text to"),
+      textAlignHorizontal: z
+        .enum(["LEFT", "CENTER", "RIGHT", "JUSTIFIED"])
+        .optional()
+        .describe("Horizontal text alignment. Use RIGHT for Arabic/RTL text."),
+      textAutoResize: z
+        .enum(["WIDTH_AND_HEIGHT", "HEIGHT", "NONE", "TRUNCATE"])
+        .optional()
+        .describe("Text resize behavior. Use HEIGHT for fixed-width text that wraps."),
     },
-    async ({ x, y, text, fontSize, fontWeight, fontColor, name, parentId }) => {
+    async ({ x, y, text, fontSize, fontWeight, fontColor, name, parentId, textAlignHorizontal, textAutoResize }) => {
       try {
         const result = await sendCommandToFigma("create_text", {
           x,
@@ -190,6 +198,8 @@ export function registerCreationTools(server: McpServer): void {
           fontColor: fontColor || { r: 0, g: 0, b: 0, a: 1 },
           name: name || "Text",
           parentId,
+          textAlignHorizontal,
+          textAutoResize,
         });
         const typedResult = result as { name: string; id: string };
         return {

--- a/src/talk_to_figma_mcp/tools/text-tools.ts
+++ b/src/talk_to_figma_mcp/tools/text-tools.ts
@@ -564,4 +564,42 @@ export function registerTextTools(server: McpServer): void {
       }
     }
   );
+
+  // Set Text Align Tool
+  server.tool(
+    "set_text_align",
+    "Set the text alignment of a text node in Figma. Use textAlignHorizontal RIGHT for RTL/Arabic text.",
+    {
+      nodeId: z.string().describe("The ID of the text node to modify"),
+      textAlignHorizontal: z.enum(["LEFT", "CENTER", "RIGHT", "JUSTIFIED"]).optional().describe("Horizontal text alignment (LEFT, CENTER, RIGHT, JUSTIFIED). Use RIGHT for Arabic/RTL text."),
+      textAlignVertical: z.enum(["TOP", "CENTER", "BOTTOM"]).optional().describe("Vertical text alignment (TOP, CENTER, BOTTOM)"),
+    },
+    async ({ nodeId, textAlignHorizontal, textAlignVertical }) => {
+      try {
+        const result = await sendCommandToFigma("set_text_align", {
+          nodeId,
+          textAlignHorizontal,
+          textAlignVertical
+        });
+        const typedResult = result as { name: string, textAlignHorizontal: string, textAlignVertical: string };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Updated text alignment of node "${typedResult.name}" to horizontal: ${typedResult.textAlignHorizontal}, vertical: ${typedResult.textAlignVertical}`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error setting text alignment: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ]
+        };
+      }
+    }
+  );
 }


### PR DESCRIPTION
## Summary

- Add `set_text_align` MCP tool for setting horizontal/vertical text alignment on existing text nodes
- Add `textAlignHorizontal` and `textAutoResize` parameters to `create_text` tool
- Enables proper RTL/Arabic text rendering (RIGHT alignment) which was previously impossible

## Problem

All text created via the MCP defaults to `textAlignHorizontal: "LEFT"` with no way to change it. This makes Arabic/RTL designs fundamentally broken — text appears left-aligned even when positioned on the right side of a frame.

## Solution

### New tool: `set_text_align`
```
set_text_align(nodeId, textAlignHorizontal="RIGHT")
```
Supports: `LEFT`, `CENTER`, `RIGHT`, `JUSTIFIED` (horizontal) and `TOP`, `CENTER`, `BOTTOM` (vertical).

### Enhanced: `create_text`
```
create_text(x, y, text="Arabic text", textAlignHorizontal="RIGHT", textAutoResize="HEIGHT")
```
Two new optional parameters:
- `textAlignHorizontal`: Set alignment at creation time
- `textAutoResize`: Control text resize behavior (`WIDTH_AND_HEIGHT`, `HEIGHT`, `NONE`, `TRUNCATE`)

## Files Changed
- `src/claude_mcp_plugin/code.js` — Plugin handler + createText enhancement
- `src/talk_to_figma_mcp/tools/text-tools.ts` — `set_text_align` tool definition
- `src/talk_to_figma_mcp/tools/creation-tools.ts` — `create_text` new params

## Test plan
- [x] Create text with `textAlignHorizontal: "RIGHT"` → verified `textAlignHorizontal: "RIGHT"` in `get_node_info`
- [x] Call `set_text_align` on existing text node → verified alignment changed to RIGHT
- [x] Build succeeds with `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)