### PR TITLE
Fix MCP server command in configure-claude and README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,13 +48,19 @@ bun install
     {
       "mcpServers": {
         "ClaudeTalkToFigma": {
-          "command": "bunx",
-          "args": ["claude-talk-to-figma-mcp@latest"]
+          "command": "npx",
+          "args": ["-p", "claude-talk-to-figma-mcp@latest", "claude-talk-to-figma-mcp-server"]
         }
       }
     }
     ```
   4. Save the file ([screenshot](images/cursor-config-2.png))
+
+#### Option 3: Claude Code (CLI)
+```bash
+claude mcp add -s user ClaudeTalkToFigma -- npx -p claude-talk-to-figma-mcp@latest claude-talk-to-figma-mcp-server
+```
+This registers the MCP server globally so it's available across all projects.
 
 ### 4. Setup Figma Plugin (Required for all methods)
 Import `src/claude_mcp_plugin/manifest.json` in Figma → Menu → Plugins → Development

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -65,10 +65,11 @@ try {
 }
 
 // Add MCP configuration
+// Use -p to install the package, then run the server binary (not the launcher)
 config.mcpServers = config.mcpServers || {};
 config.mcpServers['ClaudeTalkToFigma'] = {
   command: 'npx',
-  args: [`${packageName}@latest`]
+  args: ['-p', `${packageName}@latest`, `${packageName}-server`]
 };
 
 console.log('Updated configuration for ClaudeTalkToFigma:');


### PR DESCRIPTION
## Summary
- `configure-claude.js` and the README Cursor config were registering `claude-talk-to-figma-mcp` (launcher.js) as the MCP server command instead of the actual MCP server binary (`server.js`). This causes Claude Desktop, Cursor, and Claude Code to fail because the launcher runs the setup/socket script rather than the stdio MCP server.
- Fixed by using `npx -p claude-talk-to-figma-mcp@latest claude-talk-to-figma-mcp-server`, which correctly runs `server.js` via the `-p` flag.
- Also added Claude Code CLI setup instructions as Option 3 in the README.

Fixes #45

## Reproduce
1. Run `bun run configure-claude` — this registers `npx claude-talk-to-figma-mcp@latest` in `claude_desktop_config.json`
2. Restart Claude Desktop
3. MCP server fails to connect because `launcher.js` (clone/build/socket starter) runs instead of `server.js` (stdio MCP server)

## Changes
| File | Change |
|------|--------|
| `scripts/configure-claude.js` | `args: ["claude-talk-to-figma-mcp@latest"]` → `args: ["-p", "claude-talk-to-figma-mcp@latest", "claude-talk-to-figma-mcp-server"]` |
| `readme.md` | Fixed Cursor config with the same fix, added Claude Code CLI instructions |

## Test plan
- [x] Verified `npx -p claude-talk-to-figma-mcp@latest claude-talk-to-figma-mcp-server` correctly starts the MCP server via stdio
- [x] Tested with Claude Code (`claude mcp add`) — MCP server connects and responds to tool calls
- [x] Verified `bun run configure-claude` generates the correct config in `claude_desktop_config.json`