### PR TITLE
fix: add channel verification with ping to prevent false join success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **🔗 Channel Verification**: Fixed `join_channel` accepting invalid channel codes. Now verifies connection by sending a ping after join, providing fast feedback (12s timeout) instead of waiting for first command to timeout (60s). Added internal `ping` command for connection verification.
+
 ## [0.8.1] - 2026-02-11
 
 ### Added

--- a/src/claude_mcp_plugin/code.js
+++ b/src/claude_mcp_plugin/code.js
@@ -92,6 +92,8 @@ function updateSettings(settings) {
 // Handle commands from UI
 async function handleCommand(command, params) {
   switch (command) {
+    case "ping":
+      return { status: "ok" };
     case "get_document_info":
       return await getDocumentInfo();
     case "get_selection":

--- a/src/talk_to_figma_mcp/types/index.ts
+++ b/src/talk_to_figma_mcp/types/index.ts
@@ -62,6 +62,7 @@ export type FigmaCommand =
   | "create_component_instance"
   | "export_node_as_image"
   | "join"
+  | "ping"
   | "set_corner_radius"
   | "clone_node"
   | "set_text_content"

--- a/src/talk_to_figma_mcp/utils/websocket.ts
+++ b/src/talk_to_figma_mcp/utils/websocket.ts
@@ -174,7 +174,18 @@ export async function joinChannel(channelName: string): Promise<void> {
   try {
     await sendCommandToFigma("join", { channel: channelName });
     currentChannel = channelName;
-    logger.info(`Joined channel: ${channelName}`);
+
+    try {
+      await sendCommandToFigma("ping", {}, 12000);
+      logger.info(`Joined channel: ${channelName}`);
+    } catch (verificationError) {
+      currentChannel = null;
+      const errorMsg = verificationError instanceof Error
+        ? verificationError.message
+        : String(verificationError);
+      logger.error(`Failed to verify channel ${channelName}: ${errorMsg}`);
+      throw new Error(`Failed to verify connection to channel "${channelName}". The Figma plugin may not be connected to this channel.`);
+    }
   } catch (error) {
     logger.error(`Failed to join channel: ${error instanceof Error ? error.message : String(error)}`);
     throw error;


### PR DESCRIPTION
  Fixes #51

  ## Problem

  `join_channel` reports success even with invalid channel codes because the WebSocket server auto-creates channels without verifying the Figma plugin is connected.

  ## Solution

  Added client-side verification after join:
  1. Join command sent as before
  2. Send `ping` command with 12s timeout to verify plugin responds
  3. Success if ping returns, error if timeout
  4. Reset `currentChannel` to null on failure

  ## Changes

  - Added `ping` command to FigmaCommand type
  - Added `ping` handler in Figma plugin (returns `{ status: "ok" }`)
  - Modified `joinChannel()` to verify connection after join
  - Updated CHANGELOG.md

  ## Testing

  - Invalid channel ("123"): fails within 12s with clear error ✓
  - Valid channel: works as before ✓
  - All existing tests pass (59/59) ✓