### PR TITLE
docs: document Docker installation and update Dockerfile for WebSocke…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,18 @@ FROM oven/bun:latest
 # Set the working directory in the container
 WORKDIR /app
 
-# Copy the current directory contents into the container at /app
+# Copy package files
 COPY package*.json ./
 
+# Install dependencies
 RUN bun install
 
-# Expose the port on which the API will listen
+# Copy source code
+COPY src ./src
+COPY tsconfig.json ./
+
+# Expose WebSocket port
 EXPOSE 3055
 
-# Run the server when the container launches
-CMD ["bun", "src/talk_to_figma_mcp/server.ts"]
+# Run TypeScript directly with Bun
+CMD ["bun", "run", "src/socket.ts"]

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -36,6 +36,47 @@ This single command will:
 
 ---
 
+## Alternative: Using Docker
+
+If you prefer Docker or need to run the WebSocket server in a team environment, you can use Docker instead of the standard installation method.
+
+### Prerequisites
+
+- [Docker](https://www.docker.com/get-started) installed and running
+
+### Steps
+
+#### 1. Clone and build
+
+```bash
+git clone https://github.com/arinspunk/claude-talk-to-figma-mcp.git
+cd claude-talk-to-figma-mcp
+docker build -t figma-websocket .
+```
+
+#### 2. Run the WebSocket server
+
+```bash
+docker run -d -p 3055:3055 --name figma-ws figma-websocket
+```
+
+*Verify the server is running at: `http://localhost:3055/status`*
+
+#### 3. Install the plugin and configure MCP
+
+Follow the same steps as the standard installation:
+- [Setup Figma Plugin](#2-setup-figma-plugin)
+- [Configure your Agentic Tool](#3-configure-your-agentic-tool)
+
+### Use cases
+
+Docker is especially useful for:
+- **Team environments** - Run a shared WebSocket server on a cloud instance
+- **Isolated dependencies** - Avoid installing Bun/Node.js locally
+- **Reproducible deployments** - Consistent environment across different machines
+
+---
+
 ## 2. Setup Figma Plugin
 
 1. In Figma Desktop: **Menu → Plugins → Development → Import plugin from manifest...**

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,10 @@ To use the MCP again in day-to-day work, you don't need to repeat the entire pro
 2. **Open the plugin in Figma**: You'll find it in your recent plugins list.
 3. **Connect the AI**: Copy the channel ID and tell your agent: `Connect to Figma, channel {your-ID}`.
 
+## 🐳 Alternative: Using Docker
+
+If you prefer Docker or need to run the WebSocket server in a team environment, see the [Docker installation guide](INSTALLATION.md#alternative-using-docker) in the detailed installation documentation.
+
 ## 🛠️ Capabilities
 
 **Design analysis**


### PR DESCRIPTION
## Changes

  - Add Docker installation guide to INSTALLATION.md
  - Simplify Docker section in README (link to INSTALLATION.md per existing convention)
  - Fix Dockerfile to run WebSocket server instead of MCP server

  ## What

  **Documentation:**
  - README follows the pattern: quick-start only, detailed guides → INSTALLATION.md
  
  **Dockerfile fix:**
  - Previous Dockerfile ran MCP server (`src/talk_to_figma_mcp/server.ts`)
  - MCP uses stdio communication → doesn't work in Docker containers
  - Only the WebSocket server needs to run independently

  ## Testing

  - Built and ran Docker container: `docker build -t figma-websocket . && docker run -d -p 3055:3055 figma-websocket`
  - Verified WebSocket server runs at http://localhost:3055/status