### PR TITLE
Feat: Copy full instruction instead of channelName

### DIFF
--- a/src/claude_mcp_plugin/ui.html
+++ b/src/claude_mcp_plugin/ui.html
@@ -134,7 +134,7 @@
       .dark .mcp-plugin__button {
         border-color: #5467F7;
         background-color: #5467F7;
-        color: #fffff;
+        color: #ffffff;
       }
       .mcp-plugin__button:hover {
         background-color: transparent;
@@ -298,7 +298,7 @@
           // Clipboard feature using event delegation
           this.ui.connectionStatus.addEventListener("click", (e) => {
             if (e.target.classList.contains("mcp-plugin__channel-name")) {
-              this.copyToClipboard(e.target.textContent);
+              this.copyToClipboard(`Connect to Figma, channel ${e.target.textContent}`);
             }
           });
 


### PR DESCRIPTION
Previously, the copy action only copied the variable reference. This updates the behavior to copy the full instruction sentence, giving users the complete, usable text when they hit copy.