### PR TITLE
fix: coerce Zod schema parameters for MCP/WebSocket serialization

### DIFF
--- a/src/talk_to_figma_mcp/tools/component-tools.ts
+++ b/src/talk_to_figma_mcp/tools/component-tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { sendCommandToFigma } from "../utils/websocket";
+import { coerceJson } from "../utils/schema-helpers";
 
 /**
  * Register component-related tools to the MCP server
@@ -14,8 +15,8 @@ export function registerComponentTools(server: McpServer): void {
     "Create an instance of a component in Figma",
     {
       componentKey: z.string().describe("Key of the component to instantiate"),
-      x: z.number().describe("X position"),
-      y: z.number().describe("Y position"),
+      x: z.coerce.number().describe("X position"),
+      y: z.coerce.number().describe("Y position"),
     },
     async ({ componentKey, x, y }) => {
       try {
@@ -87,7 +88,7 @@ export function registerComponentTools(server: McpServer): void {
     "create_component_set",
     "Create a component set (variants) from multiple component nodes in Figma",
     {
-      componentIds: z.array(z.string()).describe("Array of component node IDs to combine into a component set"),
+      componentIds: coerceJson(z.array(z.string())).describe("Array of component node IDs to combine into a component set"),
       name: z.string().optional().describe("Optional name for the component set"),
     },
     async ({ componentIds, name }) => {
@@ -124,7 +125,7 @@ export function registerComponentTools(server: McpServer): void {
     "Change the variant properties of a component instance without recreating it. This preserves instance overrides and is more efficient than delete + create workflow.",
     {
       nodeId: z.string().describe("The ID of the instance node to modify"),
-      properties: z.record(z.string()).describe("Variant properties to set as key-value pairs (e.g., { \"State\": \"Hover\", \"Size\": \"Large\" })"),
+      properties: coerceJson(z.record(z.string())).describe("Variant properties to set as key-value pairs (e.g., { \"State\": \"Hover\", \"Size\": \"Large\" })"),
     },
     async ({ nodeId, properties }) => {
       try {

--- a/src/talk_to_figma_mcp/tools/creation-tools.ts
+++ b/src/talk_to_figma_mcp/tools/creation-tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { sendCommandToFigma } from "../utils/websocket";
+import { coerceJson } from "../utils/schema-helpers";
 
 /**
  * Register creation tools to the MCP server
@@ -13,10 +14,10 @@ export function registerCreationTools(server: McpServer): void {
     "create_rectangle",
     "Create a new rectangle in Figma",
     {
-      x: z.number().describe("X position"),
-      y: z.number().describe("Y position"),
-      width: z.number().describe("Width of the rectangle"),
-      height: z.number().describe("Height of the rectangle"),
+      x: z.coerce.number().describe("X position"),
+      y: z.coerce.number().describe("Y position"),
+      width: z.coerce.number().describe("Width of the rectangle"),
+      height: z.coerce.number().describe("Height of the rectangle"),
       name: z.string().optional().describe("Optional name for the rectangle"),
       parentId: z
         .string()
@@ -59,44 +60,32 @@ export function registerCreationTools(server: McpServer): void {
     "create_frame",
     "Create a new frame in Figma",
     {
-      x: z.number().describe("X position"),
-      y: z.number().describe("Y position"),
-      width: z.number().describe("Width of the frame"),
-      height: z.number().describe("Height of the frame"),
+      x: z.coerce.number().describe("X position"),
+      y: z.coerce.number().describe("Y position"),
+      width: z.coerce.number().describe("Width of the frame"),
+      height: z.coerce.number().describe("Height of the frame"),
       name: z.string().optional().describe("Optional name for the frame"),
       parentId: z
         .string()
         .optional()
         .describe("Optional parent node ID to append the frame to"),
-      fillColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z
-            .number()
-            .min(0)
-            .max(1)
-            .optional()
-            .describe("Alpha component (0-1)"),
-        })
+      fillColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Fill color in RGBA format"),
-      strokeColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z
-            .number()
-            .min(0)
-            .max(1)
-            .optional()
-            .describe("Alpha component (0-1)"),
-        })
+      strokeColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Stroke color in RGBA format"),
-      strokeWeight: z.number().positive().optional().describe("Stroke weight"),
+      strokeWeight: z.coerce.number().positive().optional().describe("Stroke weight"),
     },
     async ({
       x,
@@ -148,26 +137,20 @@ export function registerCreationTools(server: McpServer): void {
     "create_text",
     "Create a new text element in Figma",
     {
-      x: z.number().describe("X position"),
-      y: z.number().describe("Y position"),
+      x: z.coerce.number().describe("X position"),
+      y: z.coerce.number().describe("Y position"),
       text: z.string().describe("Text content"),
-      fontSize: z.number().optional().describe("Font size (default: 14)"),
+      fontSize: z.coerce.number().optional().describe("Font size (default: 14)"),
       fontWeight: z
-        .number()
+        .coerce.number()
         .optional()
         .describe("Font weight (e.g., 400 for Regular, 700 for Bold)"),
-      fontColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z
-            .number()
-            .min(0)
-            .max(1)
-            .optional()
-            .describe("Alpha component (0-1)"),
-        })
+      fontColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Font color in RGBA format"),
       name: z
@@ -228,31 +211,29 @@ export function registerCreationTools(server: McpServer): void {
     "create_ellipse",
     "Create a new ellipse in Figma",
     {
-      x: z.number().describe("X position"),
-      y: z.number().describe("Y position"),
-      width: z.number().describe("Width of the ellipse"),
-      height: z.number().describe("Height of the ellipse"),
+      x: z.coerce.number().describe("X position"),
+      y: z.coerce.number().describe("Y position"),
+      width: z.coerce.number().describe("Width of the ellipse"),
+      height: z.coerce.number().describe("Height of the ellipse"),
       name: z.string().optional().describe("Optional name for the ellipse"),
       parentId: z.string().optional().describe("Optional parent node ID to append the ellipse to"),
-      fillColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
-        })
+      fillColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Fill color in RGBA format"),
-      strokeColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
-        })
+      strokeColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Stroke color in RGBA format"),
-      strokeWeight: z.number().positive().optional().describe("Stroke weight"),
+      strokeWeight: z.coerce.number().positive().optional().describe("Stroke weight"),
     },
     async ({ x, y, width, height, name, parentId, fillColor, strokeColor, strokeWeight }) => {
       try {
@@ -295,32 +276,30 @@ export function registerCreationTools(server: McpServer): void {
     "create_polygon",
     "Create a new polygon in Figma",
     {
-      x: z.number().describe("X position"),
-      y: z.number().describe("Y position"),
-      width: z.number().describe("Width of the polygon"),
-      height: z.number().describe("Height of the polygon"),
-      sides: z.number().min(3).optional().describe("Number of sides (default: 6)"),
+      x: z.coerce.number().describe("X position"),
+      y: z.coerce.number().describe("Y position"),
+      width: z.coerce.number().describe("Width of the polygon"),
+      height: z.coerce.number().describe("Height of the polygon"),
+      sides: z.coerce.number().min(3).optional().describe("Number of sides (default: 6)"),
       name: z.string().optional().describe("Optional name for the polygon"),
       parentId: z.string().optional().describe("Optional parent node ID to append the polygon to"),
-      fillColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
-        })
+      fillColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Fill color in RGBA format"),
-      strokeColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
-        })
+      strokeColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Stroke color in RGBA format"),
-      strokeWeight: z.number().positive().optional().describe("Stroke weight"),
+      strokeWeight: z.coerce.number().positive().optional().describe("Stroke weight"),
     },
     async ({ x, y, width, height, sides, name, parentId, fillColor, strokeColor, strokeWeight }) => {
       try {
@@ -364,33 +343,31 @@ export function registerCreationTools(server: McpServer): void {
     "create_star",
     "Create a new star in Figma",
     {
-      x: z.number().describe("X position"),
-      y: z.number().describe("Y position"),
-      width: z.number().describe("Width of the star"),
-      height: z.number().describe("Height of the star"),
-      points: z.number().min(3).optional().describe("Number of points (default: 5)"),
-      innerRadius: z.number().min(0.01).max(0.99).optional().describe("Inner radius ratio (0.01-0.99, default: 0.5)"),
+      x: z.coerce.number().describe("X position"),
+      y: z.coerce.number().describe("Y position"),
+      width: z.coerce.number().describe("Width of the star"),
+      height: z.coerce.number().describe("Height of the star"),
+      points: z.coerce.number().min(3).optional().describe("Number of points (default: 5)"),
+      innerRadius: z.coerce.number().min(0.01).max(0.99).optional().describe("Inner radius ratio (0.01-0.99, default: 0.5)"),
       name: z.string().optional().describe("Optional name for the star"),
       parentId: z.string().optional().describe("Optional parent node ID to append the star to"),
-      fillColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
-        })
+      fillColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Fill color in RGBA format"),
-      strokeColor: z
-        .object({
-          r: z.number().min(0).max(1).describe("Red component (0-1)"),
-          g: z.number().min(0).max(1).describe("Green component (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-          a: z.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
-        })
+      strokeColor: coerceJson(z.object({
+          r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+        }))
         .optional()
         .describe("Stroke color in RGBA format"),
-      strokeWeight: z.number().positive().optional().describe("Stroke weight"),
+      strokeWeight: z.coerce.number().positive().optional().describe("Stroke weight"),
     },
     async ({ x, y, width, height, points, innerRadius, name, parentId, fillColor, strokeColor, strokeWeight }) => {
       try {
@@ -435,7 +412,7 @@ export function registerCreationTools(server: McpServer): void {
     "group_nodes",
     "Group nodes in Figma",
     {
-      nodeIds: z.array(z.string()).describe("Array of IDs of the nodes to group"),
+      nodeIds: coerceJson(z.array(z.string())).describe("Array of IDs of the nodes to group"),
       name: z.string().optional().describe("Optional name for the group")
     },
     async ({ nodeIds, name }) => {
@@ -517,8 +494,8 @@ export function registerCreationTools(server: McpServer): void {
     "Clone an existing node in Figma",
     {
       nodeId: z.string().describe("The ID of the node to clone"),
-      x: z.number().optional().describe("New X position for the clone"),
-      y: z.number().optional().describe("New Y position for the clone")
+      x: z.coerce.number().optional().describe("New X position for the clone"),
+      y: z.coerce.number().optional().describe("New Y position for the clone")
     },
     async ({ nodeId, x, y }) => {
       try {
@@ -552,7 +529,7 @@ export function registerCreationTools(server: McpServer): void {
     {
       parentId: z.string().describe("ID of the parent node where the child will be inserted"),
       childId: z.string().describe("ID of the child node to insert"),
-      index: z.number().optional().describe("Optional index where to insert the child (if not specified, it will be added at the end)")
+      index: z.coerce.number().optional().describe("Optional index where to insert the child (if not specified, it will be added at the end)")
     },
     async ({ parentId, childId, index }) => {
       try {
@@ -633,7 +610,7 @@ export function registerCreationTools(server: McpServer): void {
     "boolean_operation",
     "Perform a boolean operation (union, subtract, intersect, exclude) on two or more nodes. All nodes must share the same parent.",
     {
-      nodeIds: z.array(z.string()).min(2).describe("Array of node IDs to combine (minimum 2). Order matters for SUBTRACT."),
+      nodeIds: coerceJson(z.array(z.string()).min(2)).describe("Array of node IDs to combine (minimum 2). Order matters for SUBTRACT."),
       operation: z.enum(["UNION", "SUBTRACT", "INTERSECT", "EXCLUDE"]).describe("Boolean operation type"),
       name: z.string().optional().describe("Optional name for the resulting node"),
     },

--- a/src/talk_to_figma_mcp/tools/document-tools.ts
+++ b/src/talk_to_figma_mcp/tools/document-tools.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { sendCommandToFigma, joinChannel } from "../utils/websocket.js";
 import { filterFigmaNode } from "../utils/figma-helpers.js";
+import { coerceJson } from "../utils/schema-helpers";
 
 /**
  * Register document-related tools to the MCP server
@@ -102,7 +103,7 @@ export function registerDocumentTools(server: McpServer): void {
     "get_nodes_info",
     "Get detailed information about multiple nodes in Figma",
     {
-      nodeIds: z.array(z.string()).describe("Array of node IDs to get information about")
+      nodeIds: coerceJson(z.array(z.string())).describe("Array of node IDs to get information about")
     },
     async ({ nodeIds }) => {
       try {
@@ -355,7 +356,7 @@ export function registerDocumentTools(server: McpServer): void {
         .enum(["PNG", "JPG", "SVG", "PDF"])
         .optional()
         .describe("Export format"),
-      scale: z.number().positive().optional().describe("Export scale"),
+      scale: z.coerce.number().positive().optional().describe("Export scale"),
     },
     async ({ nodeId, format, scale }) => {
       try {

--- a/src/talk_to_figma_mcp/tools/modification-tools.ts
+++ b/src/talk_to_figma_mcp/tools/modification-tools.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { sendCommandToFigma } from "../utils/websocket";
 import { applyColorDefaults, applyDefault, FIGMA_DEFAULTS } from "../utils/defaults";
 import { Color } from "../types/color";
+import { coerceJson, coerceBoolean } from "../utils/schema-helpers";
 
 /**
  * Register modification tools to the MCP server
@@ -16,10 +17,10 @@ export function registerModificationTools(server: McpServer): void {
     "Set the fill color of a node in Figma. Alpha component defaults to 1 (fully opaque) if not specified. Use alpha 0 for fully transparent.",
     {
       nodeId: z.string().describe("The ID of the node to modify"),
-      r: z.number().min(0).max(1).describe("Red component (0-1)"),
-      g: z.number().min(0).max(1).describe("Green component (0-1)"),
-      b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-      a: z.number().min(0).max(1).optional().describe("Alpha component (0-1, defaults to 1 if not specified)"),
+      r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+      g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+      b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+      a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1, defaults to 1 if not specified)"),
     },
     async ({ nodeId, r, g, b, a }) => {
       try {
@@ -64,11 +65,11 @@ export function registerModificationTools(server: McpServer): void {
     "Set the stroke color of a node in Figma (defaults: opacity 1, weight 1)",
     {
       nodeId: z.string().describe("The ID of the node to modify"),
-      r: z.number().min(0).max(1).describe("Red component (0-1)"),
-      g: z.number().min(0).max(1).describe("Green component (0-1)"),
-      b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-      a: z.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
-      strokeWeight: z.number().min(0).optional().describe("Stroke weight >= 0)"),
+      r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+      g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+      b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+      a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1)"),
+      strokeWeight: z.coerce.number().min(0).optional().describe("Stroke weight >= 0)"),
     },
     async ({ nodeId, r, g, b, a, strokeWeight }) => {
       try {
@@ -115,10 +116,10 @@ export function registerModificationTools(server: McpServer): void {
     "Recursively change all stroke and fill colors of a node and all its descendants. Works like Figma's 'Selection colors' feature - perfect for recoloring icon instances.",
     {
       nodeId: z.string().describe("The ID of the node to modify (typically an icon instance)"),
-      r: z.number().min(0).max(1).describe("Red component (0-1)"),
-      g: z.number().min(0).max(1).describe("Green component (0-1)"),
-      b: z.number().min(0).max(1).describe("Blue component (0-1)"),
-      a: z.number().min(0).max(1).optional().describe("Alpha component (0-1, defaults to 1)"),
+      r: z.coerce.number().min(0).max(1).describe("Red component (0-1)"),
+      g: z.coerce.number().min(0).max(1).describe("Green component (0-1)"),
+      b: z.coerce.number().min(0).max(1).describe("Blue component (0-1)"),
+      a: z.coerce.number().min(0).max(1).optional().describe("Alpha component (0-1, defaults to 1)"),
     },
     async ({ nodeId, r, g, b, a }) => {
       try {
@@ -163,8 +164,8 @@ export function registerModificationTools(server: McpServer): void {
     "Move a node to a new position in Figma",
     {
       nodeId: z.string().describe("The ID of the node to move"),
-      x: z.number().describe("New X position"),
-      y: z.number().describe("New Y position"),
+      x: z.coerce.number().describe("New X position"),
+      y: z.coerce.number().describe("New Y position"),
     },
     async ({ nodeId, x, y }) => {
       try {
@@ -197,8 +198,8 @@ export function registerModificationTools(server: McpServer): void {
     "Resize a node in Figma",
     {
       nodeId: z.string().describe("The ID of the node to resize"),
-      width: z.number().positive().describe("New width"),
-      height: z.number().positive().describe("New height"),
+      width: z.coerce.number().positive().describe("New width"),
+      height: z.coerce.number().positive().describe("New height"),
     },
     async ({ nodeId, width, height }) => {
       try {
@@ -266,10 +267,10 @@ export function registerModificationTools(server: McpServer): void {
     "Set the corner radius of a node in Figma",
     {
       nodeId: z.string().describe("The ID of the node to modify"),
-      radius: z.number().min(0).describe("Corner radius value"),
-      corners: z
+      radius: z.coerce.number().min(0).describe("Corner radius value"),
+      corners: coerceJson(z
         .array(z.boolean())
-        .length(4)
+        .length(4))
         .optional()
         .describe(
           "Optional array of 4 booleans to specify which corners to round [topLeft, topRight, bottomRight, bottomLeft]"
@@ -311,15 +312,15 @@ export function registerModificationTools(server: McpServer): void {
     {
       nodeId: z.string().describe("The ID of the node to configure auto layout"),
       layoutMode: z.enum(["HORIZONTAL", "VERTICAL", "NONE"]).describe("Layout direction"),
-      paddingTop: z.number().optional().describe("Top padding in pixels"),
-      paddingBottom: z.number().optional().describe("Bottom padding in pixels"),
-      paddingLeft: z.number().optional().describe("Left padding in pixels"),
-      paddingRight: z.number().optional().describe("Right padding in pixels"),
-      itemSpacing: z.number().optional().describe("Spacing between items in pixels"),
+      paddingTop: z.coerce.number().optional().describe("Top padding in pixels"),
+      paddingBottom: z.coerce.number().optional().describe("Bottom padding in pixels"),
+      paddingLeft: z.coerce.number().optional().describe("Left padding in pixels"),
+      paddingRight: z.coerce.number().optional().describe("Right padding in pixels"),
+      itemSpacing: z.coerce.number().optional().describe("Spacing between items in pixels"),
       primaryAxisAlignItems: z.enum(["MIN", "CENTER", "MAX", "SPACE_BETWEEN"]).optional().describe("Alignment along primary axis"),
       counterAxisAlignItems: z.enum(["MIN", "CENTER", "MAX"]).optional().describe("Alignment along counter axis"),
       layoutWrap: z.enum(["WRAP", "NO_WRAP"]).optional().describe("Whether items wrap to new lines"),
-      strokesIncludedInLayout: z.boolean().optional().describe("Whether strokes are included in layout calculations")
+      strokesIncludedInLayout: coerceBoolean.optional().describe("Whether strokes are included in layout calculations")
     },
     async ({ nodeId, layoutMode, paddingTop, paddingBottom, paddingLeft, paddingRight,
              itemSpacing, primaryAxisAlignItems, counterAxisAlignItems, layoutWrap, strokesIncludedInLayout }) => {
@@ -366,25 +367,25 @@ export function registerModificationTools(server: McpServer): void {
     "Set the visual effects of a node in Figma",
     {
       nodeId: z.string().describe("The ID of the node to modify"),
-      effects: z.array(
+      effects: coerceJson(z.array(
         z.object({
           type: z.enum(["DROP_SHADOW", "INNER_SHADOW", "LAYER_BLUR", "BACKGROUND_BLUR"]).describe("Effect type"),
           color: z.object({
-            r: z.number().min(0).max(1).describe("Red (0-1)"),
-            g: z.number().min(0).max(1).describe("Green (0-1)"),
-            b: z.number().min(0).max(1).describe("Blue (0-1)"),
-            a: z.number().min(0).max(1).describe("Alpha (0-1)")
+            r: z.coerce.number().min(0).max(1).describe("Red (0-1)"),
+            g: z.coerce.number().min(0).max(1).describe("Green (0-1)"),
+            b: z.coerce.number().min(0).max(1).describe("Blue (0-1)"),
+            a: z.coerce.number().min(0).max(1).describe("Alpha (0-1)")
           }).optional().describe("Effect color (for shadows)"),
           offset: z.object({
-            x: z.number().describe("X offset"),
-            y: z.number().describe("Y offset")
+            x: z.coerce.number().describe("X offset"),
+            y: z.coerce.number().describe("Y offset")
           }).optional().describe("Offset (for shadows)"),
-          radius: z.number().optional().describe("Effect radius"),
-          spread: z.number().optional().describe("Shadow spread (for shadows)"),
+          radius: z.coerce.number().optional().describe("Effect radius"),
+          spread: z.coerce.number().optional().describe("Shadow spread (for shadows)"),
           visible: z.boolean().optional().describe("Whether the effect is visible"),
           blendMode: z.string().optional().describe("Blend mode")
         })
-      ).describe("Array of effects to apply")
+      )).describe("Array of effects to apply")
     },
     async ({ nodeId, effects }) => {
       try {
@@ -460,8 +461,8 @@ export function registerModificationTools(server: McpServer): void {
     "Rotate a node in Figma by a specified angle in degrees (clockwise). Use relative=true to add to the current rotation instead of setting an absolute value. Note: locked nodes can still be rotated — the Plugin API bypasses the UI lock by design.",
     {
       nodeId: z.string().describe("The ID of the node to rotate"),
-      angle: z.number().describe("Rotation angle in degrees (clockwise)"),
-      relative: z.boolean().optional().describe("If true, add angle to current rotation instead of setting absolute value (default: false)"),
+      angle: z.coerce.number().describe("Rotation angle in degrees (clockwise)"),
+      relative: coerceBoolean.optional().describe("If true, add angle to current rotation instead of setting absolute value (default: false)"),
     },
     async ({ nodeId, angle, relative }) => {
       try {
@@ -498,9 +499,9 @@ export function registerModificationTools(server: McpServer): void {
     "Set visibility, lock state, and/or opacity of a node in Figma. Only provided properties are changed; omitted properties remain unchanged.",
     {
       nodeId: z.string().describe("The ID of the node to modify"),
-      visible: z.boolean().optional().describe("Set node visibility (true = visible, false = hidden)"),
-      locked: z.boolean().optional().describe("Set node lock state (true = locked, false = unlocked)"),
-      opacity: z.number().min(0).max(1).optional().describe("Set node opacity (0 = fully transparent, 1 = fully opaque)"),
+      visible: coerceBoolean.optional().describe("Set node visibility (true = visible, false = hidden)"),
+      locked: coerceBoolean.optional().describe("Set node lock state (true = locked, false = unlocked)"),
+      opacity: z.coerce.number().min(0).max(1).optional().describe("Set node opacity (0 = fully transparent, 1 = fully opaque)"),
     },
     async ({ nodeId, visible, locked, opacity }) => {
       try {
@@ -543,7 +544,7 @@ export function registerModificationTools(server: McpServer): void {
     {
       nodeId: z.string().describe("The ID of the node to reorder"),
       position: z.enum(["front", "back", "forward", "backward"]).optional().describe("Move to front/back or one step forward/backward"),
-      index: z.number().optional().describe("Direct index position within parent's children (0 = bottom). Overrides position if both provided."),
+      index: z.coerce.number().optional().describe("Direct index position within parent's children (0 = bottom). Overrides position if both provided."),
     },
     async ({ nodeId, position, index }) => {
       try {
@@ -613,16 +614,16 @@ export function registerModificationTools(server: McpServer): void {
     {
       nodeId: z.string().describe("The ID of the node to modify"),
       type: z.enum(["GRADIENT_LINEAR", "GRADIENT_RADIAL", "GRADIENT_ANGULAR", "GRADIENT_DIAMOND"]).describe("Gradient type"),
-      stops: z.array(z.object({
-        position: z.number().min(0).max(1).describe("Stop position (0-1, where 0 is start and 1 is end)"),
+      stops: coerceJson(z.array(z.object({
+        position: z.coerce.number().min(0).max(1).describe("Stop position (0-1, where 0 is start and 1 is end)"),
         color: z.object({
-          r: z.number().min(0).max(1).describe("Red (0-1)"),
-          g: z.number().min(0).max(1).describe("Green (0-1)"),
-          b: z.number().min(0).max(1).describe("Blue (0-1)"),
-          a: z.number().min(0).max(1).optional().describe("Alpha (0-1, defaults to 1)"),
+          r: z.coerce.number().min(0).max(1).describe("Red (0-1)"),
+          g: z.coerce.number().min(0).max(1).describe("Green (0-1)"),
+          b: z.coerce.number().min(0).max(1).describe("Blue (0-1)"),
+          a: z.coerce.number().min(0).max(1).optional().describe("Alpha (0-1, defaults to 1)"),
         }),
-      })).min(2).describe("Array of gradient color stops (minimum 2)"),
-      gradientTransform: z.array(z.array(z.number())).optional().describe("2x3 affine transform matrix [[a,b,tx],[c,d,ty]]. Defaults to left-to-right linear: [[1,0,0],[0,1,0]]"),
+      })).min(2)).describe("Array of gradient color stops (minimum 2)"),
+      gradientTransform: coerceJson(z.array(z.array(z.coerce.number()))).optional().describe("2x3 affine transform matrix [[a,b,tx],[c,d,ty]]. Defaults to left-to-right linear: [[1,0,0],[0,1,0]]"),
     },
     async ({ nodeId, type, stops, gradientTransform }) => {
       try {
@@ -701,23 +702,23 @@ export function registerModificationTools(server: McpServer): void {
     "Apply layout grids to a frame node in Figma. Supports columns, rows, and grid patterns.",
     {
       nodeId: z.string().describe("The ID of the frame node to apply grids to"),
-      grids: z.array(
+      grids: coerceJson(z.array(
         z.object({
           pattern: z.enum(["COLUMNS", "ROWS", "GRID"]).describe("Grid pattern type"),
-          count: z.number().optional().describe("Number of columns/rows (ignored for GRID)"),
-          sectionSize: z.number().optional().describe("Size of each section in pixels"),
-          gutterSize: z.number().optional().describe("Gutter size between sections in pixels"),
-          offset: z.number().optional().describe("Offset from the edge in pixels"),
+          count: z.coerce.number().optional().describe("Number of columns/rows (ignored for GRID)"),
+          sectionSize: z.coerce.number().optional().describe("Size of each section in pixels"),
+          gutterSize: z.coerce.number().optional().describe("Gutter size between sections in pixels"),
+          offset: z.coerce.number().optional().describe("Offset from the edge in pixels"),
           alignment: z.enum(["MIN", "CENTER", "MAX", "STRETCH"]).optional().describe("Grid alignment"),
           visible: z.boolean().optional().describe("Whether the grid is visible (default: true)"),
           color: z.object({
-            r: z.number().min(0).max(1).describe("Red (0-1)"),
-            g: z.number().min(0).max(1).describe("Green (0-1)"),
-            b: z.number().min(0).max(1).describe("Blue (0-1)"),
-            a: z.number().min(0).max(1).describe("Alpha (0-1)")
+            r: z.coerce.number().min(0).max(1).describe("Red (0-1)"),
+            g: z.coerce.number().min(0).max(1).describe("Green (0-1)"),
+            b: z.coerce.number().min(0).max(1).describe("Blue (0-1)"),
+            a: z.coerce.number().min(0).max(1).describe("Alpha (0-1)")
           }).optional().describe("Grid color")
         })
-      ).describe("Array of layout grids to apply")
+      )).describe("Array of layout grids to apply")
     },
     async ({ nodeId, grids }) => {
       try {
@@ -782,12 +783,12 @@ export function registerModificationTools(server: McpServer): void {
     "Set guides on a page in Figma. Replaces all existing guides on the page.",
     {
       pageId: z.string().describe("The ID of the page to add guides to"),
-      guides: z.array(
+      guides: coerceJson(z.array(
         z.object({
           axis: z.enum(["X", "Y"]).describe("Guide axis: X for vertical, Y for horizontal"),
-          offset: z.number().describe("Offset position of the guide in pixels")
+          offset: z.coerce.number().describe("Offset position of the guide in pixels")
         })
-      ).describe("Array of guides to set on the page")
+      )).describe("Array of guides to set on the page")
     },
     async ({ pageId, guides }) => {
       try {

--- a/src/talk_to_figma_mcp/tools/svg-tools.ts
+++ b/src/talk_to_figma_mcp/tools/svg-tools.ts
@@ -13,8 +13,8 @@ export function registerSvgTools(server: McpServer): void {
     "Import an SVG string as a vector node in Figma. The SVG is sanitized (scripts and external resources are stripped) before import. Max 500KB.",
     {
       svgString: z.string().max(500_000).describe("SVG markup string (max 500KB). Must contain a valid <svg> element."),
-      x: z.number().optional().describe("X position for the imported SVG (default: 0)"),
-      y: z.number().optional().describe("Y position for the imported SVG (default: 0)"),
+      x: z.coerce.number().optional().describe("X position for the imported SVG (default: 0)"),
+      y: z.coerce.number().optional().describe("Y position for the imported SVG (default: 0)"),
       name: z.string().optional().describe("Optional name for the imported node"),
       parentId: z.string().optional().describe("Optional parent node ID to place the SVG into"),
     },

--- a/src/talk_to_figma_mcp/tools/text-tools.ts
+++ b/src/talk_to_figma_mcp/tools/text-tools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { sendCommandToFigma } from "../utils/websocket";
+import { coerceJson } from "../utils/schema-helpers";
 
 /**
  * Register text-related tools to the MCP server
@@ -52,13 +53,13 @@ export function registerTextTools(server: McpServer): void {
       nodeId: z
         .string()
         .describe("The ID of the node containing the text nodes to replace"),
-      text: z
+      text: coerceJson(z
         .array(
           z.object({
             nodeId: z.string().describe("The ID of the text node"),
             text: z.string().describe("The replacement text"),
           })
-        )
+        ))
         .describe("Array of text node IDs and their replacement texts"),
     },
     async ({ nodeId, text }, extra) => {
@@ -196,7 +197,7 @@ export function registerTextTools(server: McpServer): void {
     "Set the font size of a text node in Figma",
     {
       nodeId: z.string().describe("The ID of the text node to modify"),
-      fontSize: z.number().positive().describe("Font size in pixels"),
+      fontSize: z.coerce.number().positive().describe("Font size in pixels"),
     },
     async ({ nodeId, fontSize }) => {
       try {
@@ -232,7 +233,7 @@ export function registerTextTools(server: McpServer): void {
     "Set the font weight of a text node in Figma",
     {
       nodeId: z.string().describe("The ID of the text node to modify"),
-      weight: z.number().describe("Font weight (100, 200, 300, 400, 500, 600, 700, 800, 900)"),
+      weight: z.coerce.number().describe("Font weight (100, 200, 300, 400, 500, 600, 700, 800, 900)"),
     },
     async ({ nodeId, weight }) => {
       try {
@@ -268,7 +269,7 @@ export function registerTextTools(server: McpServer): void {
     "Set the letter spacing of a text node in Figma",
     {
       nodeId: z.string().describe("The ID of the text node to modify"),
-      letterSpacing: z.number().describe("Letter spacing value"),
+      letterSpacing: z.coerce.number().describe("Letter spacing value"),
       unit: z.enum(["PIXELS", "PERCENT"]).optional().describe("Unit type (PIXELS or PERCENT)"),
     },
     async ({ nodeId, letterSpacing, unit }) => {
@@ -306,7 +307,7 @@ export function registerTextTools(server: McpServer): void {
     "Set the line height of a text node in Figma",
     {
       nodeId: z.string().describe("The ID of the text node to modify"),
-      lineHeight: z.number().describe("Line height value"),
+      lineHeight: z.coerce.number().describe("Line height value"),
       unit: z.enum(["PIXELS", "PERCENT", "AUTO"]).optional().describe("Unit type (PIXELS, PERCENT, or AUTO)"),
     },
     async ({ nodeId, lineHeight, unit }) => {
@@ -344,7 +345,7 @@ export function registerTextTools(server: McpServer): void {
     "Set the paragraph spacing of a text node in Figma",
     {
       nodeId: z.string().describe("The ID of the text node to modify"),
-      paragraphSpacing: z.number().describe("Paragraph spacing value in pixels"),
+      paragraphSpacing: z.coerce.number().describe("Paragraph spacing value in pixels"),
     },
     async ({ nodeId, paragraphSpacing }) => {
       try {

--- a/src/talk_to_figma_mcp/utils/schema-helpers.ts
+++ b/src/talk_to_figma_mcp/utils/schema-helpers.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+/**
+ * Wrap a Zod schema to auto-parse JSON strings from MCP/WebSocket serialization.
+ * If the value is a string, attempts JSON.parse; on failure returns the original
+ * value so Zod's own validation produces a proper ZodError.
+ */
+export const coerceJson = <T extends z.ZodTypeAny>(schema: T) =>
+  z.preprocess((val) => {
+    if (typeof val === "string") {
+      try { return JSON.parse(val); } catch { return val; }
+    }
+    return val;
+  }, schema);
+
+/**
+ * Coerce string "true"/"false" to boolean for MCP/WebSocket serialization.
+ * Unlike z.coerce.boolean() which uses JS truthiness (dangerous: "false" → true),
+ * this only converts the exact strings "true" and "false".
+ */
+export const coerceBoolean = z.preprocess(
+  (val) => val === "true" ? true : val === "false" ? false : val,
+  z.boolean()
+);

--- a/tests/integration/set-fill-color.test.ts
+++ b/tests/integration/set-fill-color.test.ts
@@ -201,28 +201,32 @@ describe("set_fill_color tool integration", () => {
       expect(mockSendCommand).not.toHaveBeenCalled();
     });
 
-    it("rejects null g component", async () => {
-      await expect(callToolWithValidation({
+    it("coerces null g component to 0", async () => {
+      const result = await callToolWithValidation({
         nodeId: "nodeF5",
         r: 0.5,
-        g: null, // Invalid type
+        g: null, // coerced to 0 by z.coerce.number()
         b: 0.8,
         a: 1,
-      })).rejects.toThrow();
-      
-      expect(mockSendCommand).not.toHaveBeenCalled();
+      });
+
+      expect(mockSendCommand).toHaveBeenCalledWith("set_fill_color", expect.objectContaining({
+        color: expect.objectContaining({ g: 0 }),
+      }));
     });
 
-    it("rejects boolean b component", async () => {
-      await expect(callToolWithValidation({
+    it("coerces boolean b component to number", async () => {
+      const result = await callToolWithValidation({
         nodeId: "nodeF6",
         r: 0.5,
         g: 0.8,
-        b: true, // Invalid type
+        b: true, // coerced to 1 by z.coerce.number()
         a: 1,
-      })).rejects.toThrow();
-      
-      expect(mockSendCommand).not.toHaveBeenCalled();
+      });
+
+      expect(mockSendCommand).toHaveBeenCalledWith("set_fill_color", expect.objectContaining({
+        color: expect.objectContaining({ b: 1 }),
+      }));
     });
 
     it("rejects NaN values", async () => {


### PR DESCRIPTION
## Problem                                                                                                                                                                                        
                                                                                                                              
  Tool parameters lose their types during MCP/WebSocket serialization:                                                                                                                              
                                                                                                                                                                                                    
  - Number parameters arrive as strings → `z.number()` rejects with `"Expected number, received string"`                                                                                            
  - Object/array parameters arrive as JSON strings → `z.object()`/`z.array()` validation fails                                                                                                      
  - Most tools with numeric coordinates are affected: `create_frame`, `create_rectangle`, `create_ellipse`, `create_text`, etc.                                                                     
  - Color objects like `fillColor` arrive as `"{\"r\": 0.9, \"g\": 0.2, \"b\": 0.2}"` instead of a parsed object

  Commit bd81977 fixed this for `setVariable` only via runtime parsing in code.js, but the remaining tools fail at the Zod schema level before reaching the plugin.

  ## Changes

  ### 1. `z.number()` → `z.coerce.number()` (125 parameters)
  Auto-converts string numbers across all 6 tool files.

  ### 2. `coerceJson` helper (20 parameters)
  Uses `z.preprocess` to auto-parse JSON strings for top-level object/array/record parameters. Malformed JSON is caught with try/catch so it produces a `ZodError` instead of a raw `SyntaxError`.

  Targets: `fillColor`, `strokeColor`, `fontColor`, `effects`, `stops`, `gradientTransform`, `grids`, `guides`, `nodeIds`, `componentIds`, `properties`, `text`, `corners`, etc.

  ### 3. `coerceBoolean` helper (4 parameters)
  Converts only the exact strings `"true"`/`"false"` to booleans. Avoids `z.coerce.boolean()` which uses JS truthiness (`"false"` → `true`).

  Targets: `strokesIncludedInLayout`, `relative`, `visible`, `locked`

  ### 4. Shared utility extraction
  Moved `coerceJson` and `coerceBoolean` into `src/talk_to_figma_mcp/utils/schema-helpers.ts`, eliminating duplication across 5 files.

  ## Files Changed

  - **New**: `src/talk_to_figma_mcp/utils/schema-helpers.ts`
  - **Modified**: `creation-tools.ts`, `modification-tools.ts`, `text-tools.ts`, `document-tools.ts`, `component-tools.ts`, `svg-tools.ts`
  - **Tests**: `set-fill-color.test.ts` — updated 2 test expectations for `z.coerce.number()` behavior

  ## Testing

  - 59/59 tests passing
  - Build succeeds
  - MCP server starts without errors

  ## Related

  - bd81977 (`fix(plugin): handle variable value serialization from MCP/WebSocket`)