### PR TITLE
Add set_reactions tool for prototype interactions

### DIFF
--- a/src/claude_mcp_plugin/code.js
+++ b/src/claude_mcp_plugin/code.js
@@ -290,6 +290,8 @@ async function handleCommand(command, params) {
       return await createConnector(params);
     case "create_section":
       return await createSection(params);
+    case "set_reactions":
+      return await setReactions(params);
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -5904,5 +5906,62 @@ async function createSection(params) {
     width: section.width,
     height: section.height,
     fills: section.fills,
+  };
+}
+
+// Set prototype reactions (interactions) on a node
+async function setReactions(params) {
+  if (!params || !params.nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+  if (!params.reactions || !Array.isArray(params.reactions)) {
+    throw new Error("Missing or invalid reactions parameter");
+  }
+
+  const node = await getNodeByIdSafe(params.nodeId);
+  if (!node) {
+    throw new Error(`Node not found: ${params.nodeId}`);
+  }
+
+  // Build reactions array for the Figma API
+  const reactions = params.reactions.map((r) => {
+    const reaction = {};
+
+    // Set trigger
+    if (r.trigger) {
+      reaction.trigger = { type: r.trigger.type };
+      if (r.trigger.delay !== undefined) {
+        reaction.trigger.delay = r.trigger.delay;
+      }
+    }
+
+    // Set actions array
+    if (r.actions && Array.isArray(r.actions)) {
+      reaction.actions = r.actions.map((a) => {
+        const action = { type: a.type };
+        if (a.destinationId) action.destinationId = a.destinationId;
+        if (a.navigation) action.navigation = a.navigation;
+        if (a.transition) {
+          action.transition = {
+            type: a.transition.type || "DISSOLVE",
+            easing: a.transition.easing || { type: "EASE_IN_AND_OUT" },
+            duration: a.transition.duration !== undefined ? a.transition.duration : 0.2,
+          };
+        }
+        if (a.resetVideoPosition !== undefined) action.resetVideoPosition = a.resetVideoPosition;
+        return action;
+      });
+    }
+
+    return reaction;
+  });
+
+  await node.setReactionsAsync(reactions);
+
+  return {
+    id: node.id,
+    name: node.name,
+    reactionsCount: reactions.length,
+    message: `Set ${reactions.length} reaction(s) on node "${node.name}"`,
   };
 }

--- a/src/claude_mcp_plugin/code.js
+++ b/src/claude_mcp_plugin/code.js
@@ -292,6 +292,8 @@ async function handleCommand(command, params) {
       return await createSection(params);
     case "set_reactions":
       return await setReactions(params);
+    case "get_reactions":
+      return await getReactions(params);
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -5923,6 +5925,51 @@ async function setReactions(params) {
     throw new Error(`Node not found: ${params.nodeId}`);
   }
 
+  // Set overlayPositionType on destination nodes for OVERLAY actions
+  const overlayDebug = [];
+  for (const r of params.reactions) {
+    if (r.actions && Array.isArray(r.actions)) {
+      for (const a of r.actions) {
+        if (a.type === "NODE" && a.navigation === "OVERLAY" && a.destinationId) {
+          try {
+            const destNode = await figma.getNodeByIdAsync(a.destinationId);
+            const info = { destId: a.destinationId, type: destNode ? destNode.type : "not found" };
+            if (destNode) {
+              // For instances, set overlay properties on the main component
+              let targetNode = destNode;
+              if (destNode.type === "INSTANCE") {
+                const mainComp = await destNode.getMainComponentAsync();
+                if (mainComp) {
+                  targetNode = mainComp;
+                  info.usingMainComponent = targetNode.id;
+                }
+              }
+              info.targetType = targetNode.type;
+              info.hasOverlayPositionType = "overlayPositionType" in targetNode;
+              info.beforePositionType = targetNode.overlayPositionType;
+              info.beforeBgInteraction = targetNode.overlayBackgroundInteraction;
+              try {
+                targetNode.overlayPositionType = a.overlayPositionType || "CENTER";
+                info.afterPositionType = targetNode.overlayPositionType;
+              } catch (e) {
+                info.positionTypeError = e.message || String(e);
+              }
+              try {
+                targetNode.overlayBackgroundInteraction = a.overlayBackgroundInteraction || "CLOSE_ON_CLICK_OUTSIDE";
+                info.afterBgInteraction = targetNode.overlayBackgroundInteraction;
+              } catch (e) {
+                info.bgInteractionError = e.message || String(e);
+              }
+            }
+            overlayDebug.push(info);
+          } catch (e) {
+            overlayDebug.push({ destId: a.destinationId, error: e.message || String(e) });
+          }
+        }
+      }
+    }
+  }
+
   // Build reactions array for the Figma API
   const reactions = params.reactions.map((r) => {
     const reaction = {};
@@ -5935,33 +5982,103 @@ async function setReactions(params) {
       }
     }
 
-    // Set actions array
+    // Build transition object helper
+    const buildTransition = (t) => {
+      if (!t) return null;
+      return {
+        type: t.type || "DISSOLVE",
+        easing: t.easing || { type: "EASE_IN_AND_OUT" },
+        duration: t.duration !== undefined ? t.duration : 0.2,
+      };
+    };
+
+    // Set actions - support both "actions" (array, new API) and "action" (single, old API)
     if (r.actions && Array.isArray(r.actions)) {
-      reaction.actions = r.actions.map((a) => {
-        const action = { type: a.type };
-        if (a.destinationId) action.destinationId = a.destinationId;
-        if (a.navigation) action.navigation = a.navigation;
-        if (a.transition) {
-          action.transition = {
-            type: a.transition.type || "DISSOLVE",
-            easing: a.transition.easing || { type: "EASE_IN_AND_OUT" },
-            duration: a.transition.duration !== undefined ? a.transition.duration : 0.2,
+      const mappedActions = r.actions.map((a) => {
+        if (a.type === "NODE") {
+          const nav = a.navigation || "NAVIGATE";
+          const nodeAction = {
+            type: "NODE",
+            destinationId: a.destinationId || null,
+            navigation: nav,
+            transition: buildTransition(a.transition),
+            preserveScrollPosition: a.preserveScrollPosition || false,
+            resetVideoPosition: a.resetVideoPosition || false,
+            resetScrollPosition: a.resetScrollPosition || false,
+            resetInteractiveComponents: a.resetInteractiveComponents || false,
           };
+          if (nav === "OVERLAY" && a.overlayRelativePosition) {
+            nodeAction.overlayRelativePosition = a.overlayRelativePosition;
+          }
+          return nodeAction;
+        } else if (a.type === "BACK") {
+          return { type: "BACK", transition: buildTransition(a.transition) };
+        } else if (a.type === "CLOSE") {
+          return { type: "CLOSE" };
+        } else if (a.type === "URL") {
+          return { type: "URL", url: a.url || "" };
         }
-        if (a.resetVideoPosition !== undefined) action.resetVideoPosition = a.resetVideoPosition;
-        return action;
+        return { type: a.type };
       });
+
+      reaction.actions = mappedActions;
     }
 
     return reaction;
   });
 
-  await node.setReactionsAsync(reactions);
+  // Debug: log the exact reactions being set
+  const debugJson = JSON.stringify(reactions, null, 2);
+  console.log("setReactionsAsync input:", debugJson);
+
+  try {
+    await node.setReactionsAsync(reactions);
+  } catch (e) {
+    // Try with singular "action" format (older Figma API)
+    try {
+      const reactionsOldFormat = reactions.map((r) => ({
+        trigger: r.trigger,
+        action: r.actions ? r.actions[0] : r.action,
+      }));
+      await node.setReactionsAsync(reactionsOldFormat);
+    } catch (e2) {
+      const errStr = e ? (e.message || e.toString() || JSON.stringify(e)) : "unknown";
+      const errStr2 = e2 ? (e2.message || e2.toString() || JSON.stringify(e2)) : "unknown";
+      throw new Error(`setReactionsAsync failed.\nNew API error: ${errStr}\nOld API error: ${errStr2}\nInput: ${debugJson}`);
+    }
+  }
+
+  // Verify what was actually set by reading back
+  const actualReactions = node.reactions;
+  const actualCount = actualReactions ? actualReactions.length : 0;
+  const actualJson = JSON.stringify(actualReactions, null, 2);
 
   return {
     id: node.id,
     name: node.name,
     reactionsCount: reactions.length,
-    message: `Set ${reactions.length} reaction(s) on node "${node.name}"`,
+    actualReactionsCount: actualCount,
+    sentToFigma: debugJson,
+    readBackFromFigma: actualJson,
+    overlayDebug: overlayDebug.length > 0 ? overlayDebug : undefined,
+    message: `Set ${reactions.length} reaction(s) on node "${node.name}" (verified: ${actualCount} persisted)`,
+  };
+}
+
+async function getReactions(params) {
+  if (!params || !params.nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+  const node = await getNodeByIdSafe(params.nodeId);
+  if (!node) {
+    throw new Error(`Node not found: ${params.nodeId}`);
+  }
+  const reactions = node.reactions;
+  return {
+    id: node.id,
+    name: node.name,
+    type: node.type,
+    reactionsCount: reactions ? reactions.length : 0,
+    reactions: reactions ? JSON.parse(JSON.stringify(reactions)) : [],
   };
 }

--- a/src/talk_to_figma_mcp/tools/component-tools.ts
+++ b/src/talk_to_figma_mcp/tools/component-tools.ts
@@ -174,6 +174,10 @@ export function registerComponentTools(server: McpServer): void {
             easing: z.object({ type: z.string() }).optional().describe("Easing: EASE_IN, EASE_OUT, EASE_IN_AND_OUT, LINEAR"),
             duration: z.number().optional().describe("Duration in seconds"),
           }).optional().describe("Transition animation"),
+          overlayRelativePosition: z.object({
+            x: z.number(),
+            y: z.number(),
+          }).optional().describe("Position of the overlay relative to the viewport top-left (for OVERLAY navigation)"),
         })).describe("Actions to perform when triggered"),
       })).describe("Array of reactions to set on the node"),
     },
@@ -183,12 +187,12 @@ export function registerComponentTools(server: McpServer): void {
           nodeId,
           reactions,
         });
-        const typedResult = result as { id: string; name: string; reactionsCount: number; message: string };
+        const typedResult = result as Record<string, unknown>;
         return {
           content: [
             {
               type: "text",
-              text: typedResult.message,
+              text: JSON.stringify(typedResult, null, 2),
             }
           ]
         }
@@ -198,6 +202,40 @@ export function registerComponentTools(server: McpServer): void {
             {
               type: "text",
               text: `Error setting reactions: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  // Get Reactions (Prototype Interactions) Tool
+  server.tool(
+    "get_reactions",
+    "Read all prototype interactions (reactions) from a node in Figma. Useful for debugging and inspecting existing interactions.",
+    {
+      nodeId: z.string().describe("The ID of the node to read reactions from"),
+    },
+    async ({ nodeId }) => {
+      try {
+        const result = await sendCommandToFigma("get_reactions", {
+          nodeId,
+        });
+        const typedResult = result as Record<string, unknown>;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(typedResult, null, 2),
+            }
+          ]
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error getting reactions: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
         };

--- a/src/talk_to_figma_mcp/tools/component-tools.ts
+++ b/src/talk_to_figma_mcp/tools/component-tools.ts
@@ -153,4 +153,55 @@ export function registerComponentTools(server: McpServer): void {
       }
     }
   );
+
+  // Set Reactions (Prototype Interactions) Tool
+  server.tool(
+    "set_reactions",
+    "Set prototype interactions (reactions) on a node in Figma. Use this to add hover effects, click interactions, etc. For component variants, set on the default variant to add 'While hovering -> Change to hover variant' interactions.",
+    {
+      nodeId: z.string().describe("The ID of the node to set reactions on"),
+      reactions: z.array(z.object({
+        trigger: z.object({
+          type: z.string().describe("Trigger type: ON_CLICK, ON_HOVER, ON_PRESS, ON_DRAG, AFTER_TIMEOUT, MOUSE_ENTER, MOUSE_LEAVE, MOUSE_UP, MOUSE_DOWN"),
+          delay: z.number().optional().describe("Delay in seconds (for AFTER_TIMEOUT)"),
+        }).describe("The trigger for this reaction"),
+        actions: z.array(z.object({
+          type: z.string().describe("Action type: NODE, BACK, CLOSE, URL"),
+          destinationId: z.string().optional().describe("Target node ID (for NODE type)"),
+          navigation: z.string().optional().describe("Navigation type: NAVIGATE, SWAP, OVERLAY, SCROLL_TO, CHANGE_TO"),
+          transition: z.object({
+            type: z.string().optional().describe("Transition type: DISSOLVE, SMART_ANIMATE, MOVE_IN, MOVE_OUT, PUSH, SLIDE_IN, SLIDE_OUT"),
+            easing: z.object({ type: z.string() }).optional().describe("Easing: EASE_IN, EASE_OUT, EASE_IN_AND_OUT, LINEAR"),
+            duration: z.number().optional().describe("Duration in seconds"),
+          }).optional().describe("Transition animation"),
+        })).describe("Actions to perform when triggered"),
+      })).describe("Array of reactions to set on the node"),
+    },
+    async ({ nodeId, reactions }) => {
+      try {
+        const result = await sendCommandToFigma("set_reactions", {
+          nodeId,
+          reactions,
+        });
+        const typedResult = result as { id: string; name: string; reactionsCount: number; message: string };
+        return {
+          content: [
+            {
+              type: "text",
+              text: typedResult.message,
+            }
+          ]
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error setting reactions: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    }
+  );
 }


### PR DESCRIPTION
## Summary
- New `set_reactions` MCP tool that sets prototype interactions on Figma nodes programmatically
- Plugin handler in `code.js` using `node.setReactionsAsync()` (required for `documentAccess: dynamic-page`)
- MCP tool registration in `component-tools.ts` with full Zod schema

## Use case
Enables setting "While hovering → Change to variant" interactions on component set variants without manual Figma UI work. Supports all trigger types (`ON_HOVER`, `ON_CLICK`, etc.), navigation types (`CHANGE_TO`, `NAVIGATE`, etc.), and transition animations (`SMART_ANIMATE`, `DISSOLVE`, etc.).

## Example
```json
{
  "nodeId": "460:526",
  "reactions": [{
    "trigger": { "type": "ON_HOVER" },
    "actions": [{
      "type": "NODE",
      "destinationId": "460:527",
      "navigation": "CHANGE_TO",
      "transition": {
        "type": "SMART_ANIMATE",
        "easing": { "type": "EASE_IN_AND_OUT" },
        "duration": 0.2
      }
    }]
  }]
}
```

## Test plan
- [x] Tested with component set variants (3 button component sets with hover interactions)
- [x] Verified hover interactions work in Figma presentation mode
- [ ] Test with other trigger types (ON_CLICK, AFTER_TIMEOUT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)