### PR TITLE
feat: add detach instance tool

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -96,6 +96,7 @@ Complete reference of the tools Claude can use to interact with Figma.
 | `get_remote_components` | Team libraries | Access shared components |
 | `create_component_instance` | Use components | Consistent UI elements |
 | `set_instance_variant` | Change variant properties | Switch button states |
+| `detach_instance` | Detach instance from main component | One-off component customization |
 
 ## FigJam tools
 

--- a/src/claude_mcp_plugin/code.js
+++ b/src/claude_mcp_plugin/code.js
@@ -277,6 +277,8 @@ async function handleCommand(command, params) {
       return await applyVariableToNode(params);
     case "switch_variable_mode":
       return await switchVariableMode(params);
+    case "detach_instance":
+      return await detachInstance(params);
     // ── FigJam commands ──────────────────────────────────────────────────
     case "get_figjam_elements":
       return await getFigJamElements();
@@ -5443,6 +5445,38 @@ async function switchVariableMode(params) {
     modeId: mode.modeId,
     modeName: mode.name
   };
+}
+
+
+// Detach an instance
+async function detachInstance(params) {
+  const { nodeId } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  try {
+    const node = await figma.getNodeByIdAsync(nodeId);
+    if (!node) {
+      throw new Error(`Node not found with ID: ${nodeId}`);
+    }
+
+    if (node.type !== "INSTANCE") {
+      throw new Error(`Node with ID ${nodeId} is not an INSTANCE`);
+    }
+
+    const detachedFrame = node.detachInstance();
+
+    return {
+      success: true,
+      frameId: detachedFrame.id,
+      frameName: detachedFrame.name,
+      frameType: detachedFrame.type,
+    };
+  } catch (error) {
+    throw new Error(`Error detaching instance: ${error.message}`);
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/talk_to_figma_mcp/tools/component-tools.ts
+++ b/src/talk_to_figma_mcp/tools/component-tools.ts
@@ -153,4 +153,37 @@ export function registerComponentTools(server: McpServer): void {
       }
     }
   );
+
+
+  // Detach Instance Tool
+  server.tool(
+    "detach_instance",
+    "Detach an instance of a component in Figma",
+    {
+      instanceId: z.string().describe("The ID of the instance to detach"),
+    },
+    async ({ instanceId }) => {
+      try {
+        const result = await sendCommandToFigma("detach_instance", { nodeId: instanceId });
+        const typedResult = result as { success: boolean; frameId: string; frameName: string; frameType: string };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Detached instance with ID: ${instanceId}. New frame ID: ${typedResult.frameId}, name: "${typedResult.frameName}", type: ${typedResult.frameType}`,
+            }
+          ]
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error detaching instance: ${error instanceof Error ? error.message : String(error)}`,
+            }
+          ]
+        };
+      }
+    }
+  );
 }

--- a/src/talk_to_figma_mcp/types/index.ts
+++ b/src/talk_to_figma_mcp/types/index.ts
@@ -128,4 +128,5 @@ export type FigmaCommand =
   | "set_sticky_text"
   | "create_shape_with_text"
   | "create_connector"
-  | "create_section";
+  | "create_section"
+  | "detach_instance";


### PR DESCRIPTION
Summary
---
Tool to detach instance from main component, so the LLM can access and modify nested layers.

Modifications
---

- `COMMANDS.md`: added tool description
- `src/claude_mcp_plugin/code.js`: added 1 switch case and handler command
- `src/talk_to_figma_mcp/tools/component-tools.ts`: registered component tool
- `src/talk_to_figma_mcp/types/index.ts`: added figma command type