### PR TITLE
feat(get_node_info): add depth param to cap subtree payload size

### DIFF
--- a/src/talk_to_figma_mcp/tools/document-tools.ts
+++ b/src/talk_to_figma_mcp/tools/document-tools.ts
@@ -72,11 +72,12 @@ export function registerDocumentTools(server: McpServer): void {
     "Get detailed information about a specific node in Figma",
     {
       nodeId: z.string().describe("The ID of the node to get information about"),
+      depth: z.number().int().min(0).optional().describe("How many child levels to include in full detail. Deeper levels return only id/name/type stubs."),
     },
-    async ({ nodeId }) => {
+    async ({ nodeId, depth }) => {
       try {
         const result = await sendCommandToFigma("get_node_info", { nodeId });
-        const filtered = filterFigmaNode(result);
+        const filtered = filterFigmaNode(result, depth ?? 1);
         const coordinateNote = filtered.absoluteBoundingBox && filtered.localPosition
           ? "absoluteBoundingBox contains global coordinates (relative to canvas). localPosition contains local coordinates (relative to parent, use these for move_node)."
           : undefined;
@@ -109,16 +110,17 @@ export function registerDocumentTools(server: McpServer): void {
     "get_nodes_info",
     "Get detailed information about multiple nodes in Figma",
     {
-      nodeIds: z.array(z.string()).describe("Array of node IDs to get information about")
+      nodeIds: z.array(z.string()).describe("Array of node IDs to get information about"),
+      depth: z.number().int().min(0).optional().describe("How many child levels to include in full detail. Deeper levels return only id/name/type stubs.")
     },
-    async ({ nodeIds }) => {
+    async ({ nodeIds, depth }) => {
       try {
         const results = await sendCommandToFigma('get_nodes_info', { nodeIds }) as any[];
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify(results.map((result) => filterFigmaNode(result.document || result.info)))
+              text: JSON.stringify(results.map((result) => filterFigmaNode(result.document || result.info, depth ?? 1)))
             }
           ]
         };

--- a/src/talk_to_figma_mcp/utils/figma-helpers.ts
+++ b/src/talk_to_figma_mcp/utils/figma-helpers.ts
@@ -22,7 +22,7 @@ export function rgbaToHex(color: any): string {
  * @param node - El nodo de Figma a filtrar
  * @returns El nodo filtrado o null si debe ser ignorado
  */
-export function filterFigmaNode(node: any) {
+export function filterFigmaNode(node: any, maxDepth: number = Infinity, currentDepth: number = 0) {
   // Skip VECTOR type nodes
   if (node.type === "VECTOR") {
     return null;
@@ -107,9 +107,19 @@ export function filterFigmaNode(node: any) {
   }
 
   if (node.children) {
-    filtered.children = node.children
-      .map((child: any) => filterFigmaNode(child))
-      .filter((child: any) => child !== null); // Remove null children (VECTOR nodes)
+    if (currentDepth >= maxDepth) {
+      // Beyond depth: return only minimal child stubs so the model can request deeper info on demand
+      filtered.children = node.children
+        .filter((child: any) => child.type !== "VECTOR")
+        .map((child: any) => ({ id: child.id, name: child.name, type: child.type }));
+      if (filtered.children.length > 0) {
+        filtered._childrenTruncated = true;
+      }
+    } else {
+      filtered.children = node.children
+        .map((child: any) => filterFigmaNode(child, maxDepth, currentDepth + 1))
+        .filter((child: any) => child !== null); // Remove null children (VECTOR nodes)
+    }
   }
 
   return filtered;


### PR DESCRIPTION
## Summary
- `get_node_info` and `get_nodes_info` previously recursed through the full Figma subtree via `filterFigmaNode`, so a single call on a page-level frame could return 50k+ characters — often enough to be rejected for exceeding max allowed tokens.
- This PR adds an optional `depth` parameter (default: **1**) that caps how many child levels are returned in full detail. Beyond the cap, children are emitted as `{id, name, type}` stubs plus a `_childrenTruncated: true` marker so the model knows it can drill deeper with another call.
- Backward-compatible at the tool-signature level (depth is optional). Default behavior changes from "full subtree" to "root + 1 level of children + stubs for grandchildren".

## Motivation
On a real 228-node, 9-level-deep frame, `get_node_info` returned **55,308 chars** (~14K tokens) and hit the MCP max-output limit. After this change:

| depth | chars | savings |
|---|---|---|
| 1 (new default) | ~950 | ~98% |
| 3 | ~4,100 | ~93% |
| ∞ (old behavior) | 55,308 | baseline |

Stubs preserve `id`/`name`/`type` so the model has enough signal to decide which subtree to drill into — progressive disclosure instead of blanket dump.

## Changes
- `src/talk_to_figma_mcp/utils/figma-helpers.ts` — `filterFigmaNode(node, maxDepth = Infinity, currentDepth = 0)`; at `currentDepth >= maxDepth` return child stubs + `_childrenTruncated: true`.
- `src/talk_to_figma_mcp/tools/document-tools.ts` — `get_node_info` and `get_nodes_info` take optional `depth: number` (min 0), forward to `filterFigmaNode(..., depth ?? 1)`.

## Test plan
- [x] `bun run build` succeeds
- [x] Live-tested on a real Figma file (228-node frame): default returned ~950 chars; `depth: 3` returned ~4,100 chars; same frame previously returned 55,308 chars and was rejected
- [x] Existing `filterFigmaNode` callers unaffected (only 2 callsites, both updated)
- [ ] Reviewer: sanity-check the stub format is acceptable for downstream agents