### PR TITLE
feat: add set_fill_style_id and set_stroke_style_id tools

### DIFF
--- a/src/claude_mcp_plugin/code.js
+++ b/src/claude_mcp_plugin/code.js
@@ -211,6 +211,10 @@ async function handleCommand(command, params) {
       return await setEffectStyleId(params);
     case "set_text_style_id":
       return await setTextStyleId(params);
+    case "set_fill_style_id":
+      return await setFillStyleId(params);
+    case "set_stroke_style_id":
+      return await setStrokeStyleId(params);
     case "group_nodes":
       return await groupNodes(params);
     case "ungroup_nodes":
@@ -3102,6 +3106,166 @@ async function setTextStyleId(params) {
       throw new Error(`The selected node is not a text node. Only text nodes can have text styles applied.`);
     } else {
       throw new Error(`Error setting text style ID: ${error.message}`);
+    }
+  }
+}
+
+// Set Fill Style ID Tool
+async function setFillStyleId(params) {
+  const { nodeId, fillStyleId } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  if (!fillStyleId) {
+    throw new Error("Missing fillStyleId parameter");
+  }
+
+  try {
+    let timeoutId;
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new Error("Timeout while setting fill style ID (8s). The operation took too long to complete."));
+      }, 8000);
+    });
+
+    console.log(`Starting to set fill style ID ${fillStyleId} on node ${nodeId}...`);
+
+    const nodePromise = (async () => {
+      const node = await getNodeByIdSafe(nodeId);
+      if (!node) {
+        throw new Error(`Node not found with ID: ${nodeId}`);
+      }
+
+      if (!("fillStyleId" in node)) {
+        throw new Error(`Node with ID ${nodeId} does not support fill styles (type: ${node.type})`);
+      }
+
+      console.log(`Fetching paint styles to validate style ID: ${fillStyleId}`);
+      const paintStyles = await figma.getLocalPaintStylesAsync();
+      // LLMs often pass the key (a clean hex string) rather than the full Figma ID
+      const foundStyle = paintStyles.find(style => style.id === fillStyleId || style.key === fillStyleId);
+
+      if (!foundStyle) {
+        throw new Error(`Paint style with ID "${fillStyleId}" not found. Available styles: ${paintStyles.length}`);
+      }
+
+      const actualStyleId = foundStyle.id;
+      console.log(`Paint style "${foundStyle.name}" found, applying as fill...`);
+
+      // Prefer the async setter when available; fall back to the direct property
+      if (typeof node.setFillStyleIdAsync === "function") {
+        await node.setFillStyleIdAsync(actualStyleId);
+      } else {
+        node.fillStyleId = actualStyleId;
+      }
+
+      return {
+        id: node.id,
+        name: node.name,
+        fillStyleId: node.fillStyleId,
+        styleName: foundStyle.name
+      };
+    })();
+
+    const result = await Promise.race([nodePromise, timeoutPromise])
+      .finally(() => clearTimeout(timeoutId));
+
+    console.log(`Successfully set fill style ID on node ${nodeId}`);
+    return result;
+  } catch (error) {
+    console.error(`Error setting fill style ID: ${error.message || "Unknown error"}`);
+
+    if (error.message.includes("timeout") || error.message.includes("Timeout")) {
+      throw new Error(`The operation timed out after 8 seconds. Try with a simpler node.`);
+    } else if (error.message.includes("not found") && error.message.includes("Node")) {
+      throw new Error(`Node with ID "${nodeId}" not found. Make sure the node exists in the current document.`);
+    } else if (error.message.includes("not found") && error.message.includes("style")) {
+      throw new Error(`Paint style with ID "${fillStyleId}" not found. Make sure the style exists in your local styles.`);
+    } else if (error.message.includes("does not support")) {
+      throw new Error(`The selected node type does not support fill styles.`);
+    } else {
+      throw new Error(`Error setting fill style ID: ${error.message}`);
+    }
+  }
+}
+
+// Set Stroke Style ID Tool
+async function setStrokeStyleId(params) {
+  const { nodeId, strokeStyleId } = params || {};
+
+  if (!nodeId) {
+    throw new Error("Missing nodeId parameter");
+  }
+
+  if (!strokeStyleId) {
+    throw new Error("Missing strokeStyleId parameter");
+  }
+
+  try {
+    let timeoutId;
+    const timeoutPromise = new Promise((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new Error("Timeout while setting stroke style ID (8s). The operation took too long to complete."));
+      }, 8000);
+    });
+
+    console.log(`Starting to set stroke style ID ${strokeStyleId} on node ${nodeId}...`);
+
+    const nodePromise = (async () => {
+      const node = await getNodeByIdSafe(nodeId);
+      if (!node) {
+        throw new Error(`Node not found with ID: ${nodeId}`);
+      }
+
+      if (!("strokeStyleId" in node)) {
+        throw new Error(`Node with ID ${nodeId} does not support stroke styles (type: ${node.type})`);
+      }
+
+      console.log(`Fetching paint styles to validate style ID: ${strokeStyleId}`);
+      const paintStyles = await figma.getLocalPaintStylesAsync();
+      const foundStyle = paintStyles.find(style => style.id === strokeStyleId || style.key === strokeStyleId);
+
+      if (!foundStyle) {
+        throw new Error(`Paint style with ID "${strokeStyleId}" not found. Available styles: ${paintStyles.length}`);
+      }
+
+      const actualStyleId = foundStyle.id;
+      console.log(`Paint style "${foundStyle.name}" found, applying as stroke...`);
+
+      if (typeof node.setStrokeStyleIdAsync === "function") {
+        await node.setStrokeStyleIdAsync(actualStyleId);
+      } else {
+        node.strokeStyleId = actualStyleId;
+      }
+
+      return {
+        id: node.id,
+        name: node.name,
+        strokeStyleId: node.strokeStyleId,
+        styleName: foundStyle.name
+      };
+    })();
+
+    const result = await Promise.race([nodePromise, timeoutPromise])
+      .finally(() => clearTimeout(timeoutId));
+
+    console.log(`Successfully set stroke style ID on node ${nodeId}`);
+    return result;
+  } catch (error) {
+    console.error(`Error setting stroke style ID: ${error.message || "Unknown error"}`);
+
+    if (error.message.includes("timeout") || error.message.includes("Timeout")) {
+      throw new Error(`The operation timed out after 8 seconds. Try with a simpler node.`);
+    } else if (error.message.includes("not found") && error.message.includes("Node")) {
+      throw new Error(`Node with ID "${nodeId}" not found. Make sure the node exists in the current document.`);
+    } else if (error.message.includes("not found") && error.message.includes("style")) {
+      throw new Error(`Paint style with ID "${strokeStyleId}" not found. Make sure the style exists in your local styles.`);
+    } else if (error.message.includes("does not support")) {
+      throw new Error(`The selected node type does not support stroke styles.`);
+    } else {
+      throw new Error(`Error setting stroke style ID: ${error.message}`);
     }
   }
 }

--- a/src/talk_to_figma_mcp/tools/modification-tools.ts
+++ b/src/talk_to_figma_mcp/tools/modification-tools.ts
@@ -455,6 +455,82 @@ export function registerModificationTools(server: McpServer): void {
     }
   );
 
+  // Set Fill Style ID Tool
+  server.tool(
+    "set_fill_style_id",
+    "Apply a paint style to a node's fill in Figma. Use get_styles to find available paint style IDs.",
+    {
+      nodeId: z.string().describe("The ID of the node to modify"),
+      fillStyleId: z.string().describe("The ID of the paint style to apply as the node's fill")
+    },
+    async ({ nodeId, fillStyleId }) => {
+      try {
+        const result = await sendCommandToFigma("set_fill_style_id", {
+          nodeId,
+          fillStyleId
+        });
+
+        const typedResult = result as { name: string, fillStyleId: string };
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Successfully applied fill style to node "${typedResult.name}"`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error setting fill style: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ]
+        };
+      }
+    }
+  );
+
+  // Set Stroke Style ID Tool
+  server.tool(
+    "set_stroke_style_id",
+    "Apply a paint style to a node's stroke in Figma. Use get_styles to find available paint style IDs.",
+    {
+      nodeId: z.string().describe("The ID of the node to modify"),
+      strokeStyleId: z.string().describe("The ID of the paint style to apply as the node's stroke")
+    },
+    async ({ nodeId, strokeStyleId }) => {
+      try {
+        const result = await sendCommandToFigma("set_stroke_style_id", {
+          nodeId,
+          strokeStyleId
+        });
+
+        const typedResult = result as { name: string, strokeStyleId: string };
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Successfully applied stroke style to node "${typedResult.name}"`
+            }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error setting stroke style: ${error instanceof Error ? error.message : String(error)}`
+            }
+          ]
+        };
+      }
+    }
+  );
+
   // Rotate Node Tool
   server.tool(
     "rotate_node",

--- a/src/talk_to_figma_mcp/types/index.ts
+++ b/src/talk_to_figma_mcp/types/index.ts
@@ -83,6 +83,8 @@ export type FigmaCommand =
   | "set_effects"
   | "set_effect_style_id"
   | "set_text_style_id"
+  | "set_fill_style_id"
+  | "set_stroke_style_id"
   | "group_nodes"
   | "ungroup_nodes"
   | "flatten_node"


### PR DESCRIPTION
## Summary

Adds two new tools — `set_fill_style_id` and `set_stroke_style_id` — that bind paint styles to existing node fills/strokes. Mirrors the existing `set_text_style_id` / `set_effect_style_id` pattern.

Closes the gap where paint styles could be **created** (via `create_paint_style`) but not **applied** to existing nodes from the MCP, forcing users into Figma's UI for every swatch and component fill.

## Why

Working on a brand design system, I created 8 paint styles via `create_paint_style` and then wanted to bind them to existing swatch fills and component fills programmatically. The fork ships `set_text_style_id` and `set_effect_style_id` but not the equivalent for paints — `set_fill_color` only writes raw RGB and doesn't bind a `fillStyleId`. So even with the right styles in the local library, the agent has to hand the work back to the user.

These two tools close the loop: once paint styles exist, an agent can apply them across the file in parallel just like text styles.

## Implementation

- `set_fill_style_id(nodeId, fillStyleId)` — looks up the paint style by `id` or `key` (matches the `set_text_style_id` behavior, since LLMs often pass the cleaner hex key from `get_styles` rather than the full Figma id). Applies via `setFillStyleIdAsync` when available, falls back to the property setter.
- `set_stroke_style_id(nodeId, strokeStyleId)` — same shape for strokes.

## Files changed

- `src/talk_to_figma_mcp/types/index.ts` — add the two command names to the union
- `src/talk_to_figma_mcp/tools/modification-tools.ts` — register the two MCP tools (cloned from `set_effect_style_id`)
- `src/claude_mcp_plugin/code.js` — add switch cases + handler functions (cloned from `setEffectStyleId` / `setTextStyleId`, swapped to use `getLocalPaintStylesAsync` and the fill/stroke setters)

242 lines added, 0 removed.

## Build

\`npx tsup\` builds clean (ESM + CJS). The DTS build fails on a pre-existing TS error in \`src/socket.ts:513\` (\`Server<WebSocketData>\` generic) unrelated to this change.

## Test plan

- [x] JS build succeeds, new tools land in `dist/talk_to_figma_mcp/server.js` (4 references)
- [x] Tool descriptions follow the existing convention
- [x] Error handling matches `setTextStyleId` / `setEffectStyleId` (timeout, not-found, type-mismatch)
- [ ] Manual test: create a paint style → call `set_fill_style_id` on a rectangle → verify Figma binds the style (verifier should re-run \`get_node_info\` and confirm \`fillStyleId\` is set)
- [ ] Manual test: same for `set_stroke_style_id` on a node with a stroke

🤖 Generated with [Claude Code](https://claude.com/claude-code)